### PR TITLE
chore: apply governance sync and resolve ruff lint compliance

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -2,3 +2,4 @@
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1
+  - "CKV_SECRET_4:.*specifications/api/.*\\.json$"

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,edn,hcl,iterm,nd,uncomplete,ves
+ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,preceeding,uncomplete,ves

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,4 +1,7 @@
 {
-  "Exclude": ["\\.md$", "\\.mdx$"],
-  "DisableIndentSize": true
+  "Disable": {
+    "IndentSize": true,
+    "Indentation": true
+  },
+  "Exclude": ["[.]md$", "[.]mdx$"]
 }

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile = black
+force_sort_within_sections = False
+combine_as_imports = True

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Auto-generated files -- do not reformat
+**/src/gen/
+**/src/v2/gen/
+**/src/generated/
+**/*.gen.ts
+**/*.gen.js
+**/*.gen.d.ts

--- a/.python-lint
+++ b/.python-lint
@@ -1,0 +1,51 @@
+[MAIN]
+py-version = 3.11
+jobs = 0
+
+[FORMAT]
+max-line-length = 88
+indent-string = '    '
+expected-line-ending-format = LF
+
+[DESIGN]
+max-args = 7
+max-branches = 15
+max-locals = 20
+max-returns = 6
+max-statements = 60
+max-attributes = 10
+max-public-methods = 25
+min-public-methods = 0
+
+[MESSAGES CONTROL]
+disable =
+    C0114,
+    C0115,
+    C0116,
+    C0206,
+    C0301,
+    C0303,
+    C0411,
+    C0413,
+    E0401,
+    E1101,
+    R0801,
+    R0903,
+    R0917,
+    R1702,
+    W0511,
+    W0611,
+    W0612,
+    W0613,
+    W0621,
+    W0622,
+    W1514
+
+[BASIC]
+good-names = i, j, k, ex, _, id, pk, db, fn, ip, ok, df
+
+[SIMILARITIES]
+min-similarity-lines = 10
+ignore-comments = yes
+ignore-docstrings = yes
+ignore-imports = yes

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,73 @@
+extend = "pyproject.toml"
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15

--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,9 @@
       "exclude": [
         "repo\\b",
         "bug[- ]fix(es)?",
-        "build system(s)?"
+        "build system(s)?",
+        "readme(s)?",
+        "to-?do(s)?(?=[ ,.])"
       ]
     }
   }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Governance-managed Trivy ignore list
+# Review quarterly — remove entries when upstream fixes are released
+#
+# Format: one CVE/ID per line
+# Lines starting with # are comments
+
+# CVE-2026-4539 — Low severity (CVSS 3.3) ReDoS in pygments AdlLexer
+# Transitive dependency: rich -> pygments
+# Affected: pygments <= 2.19.2 — no fix released to PyPI
+# Fix merged upstream: pygments/pygments#3064 (2026-03-25)
+# Pygments maintainers dispute this as a security issue per their security policy
+# Impact: Zero — AdlLexer handles openEHR archetype definitions, unused in this context
+# Expiry: 2026-05-31 — re-evaluate after pygments releases fix
+# Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-4539
+CVE-2026-4539

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,73 @@
+extend = "pyproject.toml"
+line-length = 88
+
+[format]
+quote-style = "double"
+indent-style = "space"
+
+[lint]
+extend-select = [
+    "E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF", "PERF", "FURB",
+    "S", "TRY", "RSE", "EM", "N", "A", "Q", "COM", "RET", "ARG", "PTH",
+    "T20", "LOG", "G", "TCH", "ANN", "PT", "D", "ERA",
+    "PLC", "PLE", "PLR", "PLW",
+    "PIE", "ISC", "ICN", "PGH", "FLY", "SLF", "TD", "FIX",
+    "YTT", "DTZ", "EXE", "FA", "INT", "INP",
+]
+ignore = [
+    "E501",
+    "COM812",
+    "ISC001",
+    "D100",
+    "D104",
+    "D203",
+    "D213",
+    "ANN401",
+    "TD002",
+    "TD003",
+    "FIX002",
+    "PLR0913",
+    "PLR0912",
+    "PLR0915",
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
+[lint.isort]
+split-on-trailing-comma = true
+combine-as-imports = true
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.pylint]
+max-args = 7
+max-returns = 6
+max-branches = 15
+
+[lint.mccabe]
+max-complexity = 15

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -6,14 +6,19 @@ import argparse
 import hashlib
 import io
 import json
+import sys
 import zipfile
-from datetime import UTC
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import requests
 import yaml
 from rich.console import Console
 from rich.progress import BarColumn, DownloadColumn, Progress, TransferSpeedColumn
+
+# HTTP status codes
+HTTP_NOT_MODIFIED = 304
 
 console = Console()
 
@@ -31,7 +36,7 @@ def load_config(config_path: Path) -> dict:
     if not config_path.exists():
         return {}
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         return yaml.safe_load(f) or {}
 
 
@@ -54,9 +59,6 @@ def save_metadata(
     file_count: int,
 ) -> None:
     """Save download metadata for versioning."""
-    from datetime import datetime
-    from email.utils import parsedate_to_datetime
-
     metadata_path = output_dir / DEFAULT_METADATA_FILE
 
     # Parse Last-Modified header to get the upstream spec date
@@ -83,7 +85,7 @@ def save_metadata(
         "source_url": DEFAULT_DOWNLOAD_URL,
     }
 
-    with open(metadata_path, "w") as f:
+    with metadata_path.open("w") as f:
         json.dump(metadata, f, indent=2)
 
     console.print(f"[dim]Metadata saved: {metadata_path}[/dim]")
@@ -95,7 +97,7 @@ def load_metadata(output_dir: Path) -> dict | None:
     """Load download metadata for versioning."""
     metadata_path = output_dir / DEFAULT_METADATA_FILE
     if metadata_path.exists():
-        with open(metadata_path) as f:
+        with metadata_path.open() as f:
             return json.load(f)
     return None
 
@@ -106,8 +108,7 @@ def download_specs(
     etag_cache: str | Path = DEFAULT_ETAG_CACHE,
     force: bool = False,
 ) -> tuple[bool, list[str]]:
-    """
-    Download and extract OpenAPI specs from F5.
+    """Download and extract OpenAPI specs from F5.
 
     Returns:
         Tuple of (changed, list of extracted files)
@@ -141,7 +142,7 @@ def download_specs(
         response = requests.get(url, headers=headers, stream=True, timeout=60)
 
         # Not modified - use cached version
-        if response.status_code == 304:
+        if response.status_code == HTTP_NOT_MODIFIED:
             console.print("[green]Specs unchanged (ETag match), using cached version[/green]")
             # Return existing files
             existing_files = [
@@ -184,11 +185,12 @@ def download_specs(
         save_metadata(output_dir, new_etag, last_modified, len(extracted_files))
 
         console.print(f"[green]Extracted {len(extracted_files)} files to {output_dir}[/green]")
-        return True, extracted_files
 
     except requests.exceptions.RequestException as e:
         console.print(f"[red]Download failed: {e}[/red]")
         raise
+    else:
+        return True, extracted_files
 
 
 def extract_zip(content: io.BytesIO, output_dir: Path) -> list[str]:
@@ -205,7 +207,7 @@ def extract_zip(content: io.BytesIO, output_dir: Path) -> list[str]:
             filename = Path(info.filename).name
             output_path = output_dir / filename
 
-            with zf.open(info) as src, open(output_path, "wb") as dst:
+            with zf.open(info) as src, output_path.open("wb") as dst:
                 dst.write(src.read())
 
             extracted.append(filename)
@@ -220,7 +222,7 @@ def list_domain_files(output_dir: Path) -> dict[str, list[str]]:
 
     for filepath in output_dir.glob("*.json"):
         try:
-            with open(filepath) as f:
+            with filepath.open() as f:
                 spec = json.load(f)
 
             paths = list(spec.get("paths", {}).keys())
@@ -237,13 +239,13 @@ def list_domain_files(output_dir: Path) -> dict[str, list[str]]:
 def compute_checksum(filepath: Path) -> str:
     """Compute SHA256 checksum of a file."""
     sha256 = hashlib.sha256()
-    with open(filepath, "rb") as f:
+    with filepath.open("rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             sha256.update(chunk)
     return sha256.hexdigest()
 
 
-def main():
+def main() -> int:
     """Main entry point for download command."""
     parser = argparse.ArgumentParser(description="Download F5 XC OpenAPI specifications")
     parser.add_argument(
@@ -282,7 +284,7 @@ def main():
     etag_cache = Path(download_config.get("etag_cache", DEFAULT_ETAG_CACHE))
 
     # Download specs
-    changed, files = download_specs(
+    _changed, files = download_specs(
         url=url,
         output_dir=output_dir,
         etag_cache=etag_cache,
@@ -305,4 +307,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -27,7 +27,7 @@ def load_json_report(report_path: Path, report_type: str = "report") -> dict | N
         return None
 
     try:
-        with open(report_path) as f:
+        with report_path.open() as f:
             return json.load(f)
     except json.JSONDecodeError as e:
         console.print(f"[red]Failed to parse {report_type}: {e}[/red]")
@@ -311,7 +311,11 @@ def _generate_legend() -> list[str]:
     ]
 
 
-def _format_value(value) -> str:
+_MAX_JSON_DISPLAY_LEN = 50
+_JSON_TRUNCATE_LEN = 47
+
+
+def _format_value(value: object) -> str:
     """Format a value for display in markdown table."""
     if value is None:
         return "-"
@@ -319,8 +323,8 @@ def _format_value(value) -> str:
         return "true" if value else "false"
     if isinstance(value, (list, dict)):
         json_str = json.dumps(value)
-        if len(json_str) > 50:
-            return f"`{json_str[:47]}...`"
+        if len(json_str) > _MAX_JSON_DISPLAY_LEN:
+            return f"`{json_str[:_JSON_TRUNCATE_LEN]}...`"
         return f"`{json_str}`"
     # Replace newlines with HTML line breaks for markdown tables
     str_value = str(value).replace("\n", "<br>")
@@ -359,7 +363,7 @@ def _get_type_badge(dtype: str) -> str:
 def _write_file(path: Path, lines: list[str]) -> None:
     """Write lines to file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with path.open("w") as f:
         f.write("\n".join(lines))
     console.print(f"[green]Generated: {path}[/green]")
 

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -20,6 +20,12 @@ from .utils.spec_loader import save_spec_to_file
 
 console = Console()
 
+# Minimum parts for dotted property paths like "paths.{path}.{method}"
+_MIN_PATH_PARTS = 3
+
+# Index of the tag segment in URL path segments (e.g., /api/namespace → "namespace")
+_TAG_SEGMENT_INDEX = 1
+
 
 @dataclass
 class ReconciliationResult:
@@ -57,7 +63,8 @@ class SpecReconciler:
         output_dir: Path,
         config: ReconciliationConfig | None = None,
         spectral_config: dict[str, Any] | None = None,
-    ):
+    ) -> None:
+        """Initialize the spec reconciler with paths and configuration."""
         self.original_dir = Path(original_dir)
         self.output_dir = Path(output_dir)
         self.config = config or ReconciliationConfig()
@@ -104,10 +111,7 @@ class SpecReconciler:
 
         for d in discrepancies:
             # Extract filename from path
-            if ":" in d.path:
-                filename = d.path.split(":")[0]
-            else:
-                filename = d.path
+            filename = d.path.split(":")[0] if ":" in d.path else d.path
 
             if filename not in grouped:
                 grouped[filename] = []
@@ -129,7 +133,7 @@ class SpecReconciler:
 
         # Load original spec
         try:
-            with open(spec_path) as f:
+            with spec_path.open() as f:
                 if spec_path.suffix == ".yaml":
                     original = yaml.safe_load(f)
                 else:
@@ -184,13 +188,13 @@ class SpecReconciler:
 
         if fix_strategy == "spectral":
             return self._apply_spectral_fix(spec, discrepancy)
-        elif fix_strategy == "relax":
+        if fix_strategy == "relax":
             return self._relax_constraint(spec, discrepancy)
-        elif fix_strategy == "tighten":
+        if fix_strategy == "tighten":
             return self._tighten_constraint(spec, discrepancy)
-        elif fix_strategy == "add":
+        if fix_strategy == "add":
             return self._add_constraint(spec, discrepancy)
-        elif fix_strategy == "remove":
+        if fix_strategy == "remove":
             return self._remove_constraint(spec, discrepancy)
 
         return None
@@ -348,7 +352,7 @@ class SpecReconciler:
             return fixer(spec, discrepancy)
         return None
 
-    def _add_servers(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
+    def _add_servers(self, spec: dict, discrepancy: Discrepancy) -> dict | None:  # noqa: ARG002
         """Add servers block from spectral config."""
         servers = self.spectral_config.get("servers")
         if servers is None:
@@ -356,7 +360,7 @@ class SpecReconciler:
         spec["servers"] = copy.deepcopy(servers)
         return spec
 
-    def _add_contact(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
+    def _add_contact(self, spec: dict, discrepancy: Discrepancy) -> dict | None:  # noqa: ARG002
         """Add contact info to spec.info."""
         contact = self.spectral_config.get("contact")
         if contact is None:
@@ -367,7 +371,7 @@ class SpecReconciler:
     def _add_tags(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
         """Derive and add tags from the API path prefix."""
         parts = discrepancy.property_name.split(".")
-        if len(parts) < 3 or parts[0] != "paths":
+        if len(parts) < _MIN_PATH_PARTS or parts[0] != "paths":
             return None
 
         path_key = parts[1]
@@ -380,8 +384,8 @@ class SpecReconciler:
 
         segments = [s for s in path_key.split("/") if s and s.startswith("{") is False]
         tag = "default"
-        if len(segments) >= 2:
-            tag = segments[1]
+        if len(segments) > _TAG_SEGMENT_INDEX:
+            tag = segments[_TAG_SEGMENT_INDEX]
         elif segments:
             tag = segments[0]
 
@@ -396,7 +400,7 @@ class SpecReconciler:
     def _remove_unused_component(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
         """Remove an unused component schema."""
         parts = discrepancy.property_name.split(".")
-        if len(parts) < 3 or parts[0] != "components" or parts[1] != "schemas":
+        if len(parts) < _MIN_PATH_PARTS or parts[0] != "components" or parts[1] != "schemas":
             return None
 
         schema_name = parts[2]
@@ -409,7 +413,7 @@ class SpecReconciler:
     def _deduplicate_operation_id(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
         """Append HTTP method suffix to duplicate operationIds."""
         parts = discrepancy.property_name.split(".")
-        if len(parts) < 3 or parts[0] != "paths":
+        if len(parts) < _MIN_PATH_PARTS or parts[0] != "paths":
             return None
 
         path_key = parts[1]
@@ -425,7 +429,7 @@ class SpecReconciler:
     def _fix_schema_example(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
         """Remove invalid default/example values from schemas."""
         parts = discrepancy.property_name.split(".")
-        if len(parts) < 3:
+        if len(parts) < _MIN_PATH_PARTS:
             return None
 
         target_key = parts[-1]
@@ -502,24 +506,19 @@ class SpecReconciler:
         api_behavior: Any,
     ) -> Any:
         """Calculate a relaxed constraint value."""
-        if constraint_type == "minLength":
+        if constraint_type == "minLength" and isinstance(api_behavior, int):
             # Lower the minimum
-            if isinstance(api_behavior, int):
-                return min(old_value or 0, api_behavior)
-        elif constraint_type == "maxLength":
+            return min(old_value or 0, api_behavior)
+        if constraint_type == "maxLength" and isinstance(api_behavior, int):
             # Raise the maximum
-            if isinstance(api_behavior, int):
-                return max(old_value or 0, api_behavior)
-        elif constraint_type == "minimum":
-            if isinstance(api_behavior, (int, float)):
-                return min(old_value or 0, api_behavior)
-        elif constraint_type == "maximum":
-            if isinstance(api_behavior, (int, float)):
-                return max(old_value or 0, api_behavior)
-        elif constraint_type == "enum":
+            return max(old_value or 0, api_behavior)
+        if constraint_type == "minimum" and isinstance(api_behavior, (int, float)):
+            return min(old_value or 0, api_behavior)
+        if constraint_type == "maximum" and isinstance(api_behavior, (int, float)):
+            return max(old_value or 0, api_behavior)
+        if constraint_type == "enum" and isinstance(api_behavior, list) and isinstance(old_value, list):
             # Add missing enum values
-            if isinstance(api_behavior, list) and isinstance(old_value, list):
-                return list(set(old_value) | set(api_behavior))
+            return list(set(old_value) | set(api_behavior))
 
         return api_behavior
 
@@ -530,24 +529,19 @@ class SpecReconciler:
         api_behavior: Any,
     ) -> Any:
         """Calculate a tightened constraint value."""
-        if constraint_type == "minLength":
+        if constraint_type == "minLength" and isinstance(api_behavior, int):
             # Raise the minimum
-            if isinstance(api_behavior, int):
-                return max(old_value or 0, api_behavior)
-        elif constraint_type == "maxLength":
+            return max(old_value or 0, api_behavior)
+        if constraint_type == "maxLength" and isinstance(api_behavior, int):
             # Lower the maximum
-            if isinstance(api_behavior, int):
-                return min(old_value or float("inf"), api_behavior)
-        elif constraint_type == "minimum":
-            if isinstance(api_behavior, (int, float)):
-                return max(old_value or float("-inf"), api_behavior)
-        elif constraint_type == "maximum":
-            if isinstance(api_behavior, (int, float)):
-                return min(old_value or float("inf"), api_behavior)
-        elif constraint_type == "enum":
+            return min(old_value or float("inf"), api_behavior)
+        if constraint_type == "minimum" and isinstance(api_behavior, (int, float)):
+            return max(old_value or float("-inf"), api_behavior)
+        if constraint_type == "maximum" and isinstance(api_behavior, (int, float)):
+            return min(old_value or float("inf"), api_behavior)
+        if constraint_type == "enum" and isinstance(api_behavior, list):
             # Restrict to only observed enum values
-            if isinstance(api_behavior, list):
-                return api_behavior
+            return api_behavior
 
         return api_behavior
 
@@ -643,28 +637,25 @@ def load_discrepancies(report_path: Path) -> list[Discrepancy]:
     if not report_path.exists():
         return []
 
-    with open(report_path) as f:
+    with report_path.open() as f:
         report = json.load(f)
 
-    discrepancies = []
-    for d in report.get("discrepancies", []):
-        discrepancies.append(
-            Discrepancy(
-                path=d.get("path", ""),
-                property_name=d.get("property_name", ""),
-                constraint_type=d.get("constraint_type", ""),
-                discrepancy_type=DiscrepancyType(d.get("discrepancy_type", "constraint_mismatch")),
-                spec_value=d.get("spec_value"),
-                api_behavior=d.get("api_behavior"),
-                test_values=d.get("test_values", []),
-                recommendation=d.get("recommendation", ""),
-            )
+    return [
+        Discrepancy(
+            path=d.get("path", ""),
+            property_name=d.get("property_name", ""),
+            constraint_type=d.get("constraint_type", ""),
+            discrepancy_type=DiscrepancyType(d.get("discrepancy_type", "constraint_mismatch")),
+            spec_value=d.get("spec_value"),
+            api_behavior=d.get("api_behavior"),
+            test_values=d.get("test_values", []),
+            recommendation=d.get("recommendation", ""),
         )
+        for d in report.get("discrepancies", [])
+    ]
 
-    return discrepancies
 
-
-def main():
+def main() -> int:
     """Main entry point for reconciliation command."""
     parser = argparse.ArgumentParser(description="Reconcile F5 XC OpenAPI specs with API behavior")
     parser.add_argument(
@@ -697,7 +688,7 @@ def main():
 
     # Load configuration
     if args.config.exists():
-        with open(args.config) as f:
+        with args.config.open() as f:
             config = yaml.safe_load(f)
     else:
         config = {}
@@ -730,7 +721,7 @@ def main():
     )
 
     # Run reconciliation
-    results = reconciler.reconcile_all(discrepancies)
+    reconciler.reconcile_all(discrepancies)
 
     # Save results
     saved = reconciler.save_results()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -22,7 +22,7 @@ def load_config(config_path: Path) -> dict:
     if not config_path.exists():
         return {}
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         return yaml.safe_load(f) or {}
 
 
@@ -30,7 +30,7 @@ def load_spec_metadata(specs_dir: Path) -> dict | None:
     """Load spec metadata from download."""
     metadata_path = specs_dir / ".spec_metadata.json"
     if metadata_path.exists():
-        with open(metadata_path) as f:
+        with metadata_path.open() as f:
             return json.load(f)
     return None
 
@@ -38,8 +38,8 @@ def load_spec_metadata(specs_dir: Path) -> dict | None:
 def get_existing_patch_numbers(base_date: str) -> list[int]:
     """Get existing patch numbers for a given base date from git tags."""
     try:
-        result = subprocess.run(
-            ["git", "tag", "-l", f"v{base_date}-*"],
+        result = subprocess.run(  # noqa: S603
+            ["git", "tag", "-l", f"v{base_date}-*"],  # noqa: S607
             capture_output=True,
             text=True,
             check=True,
@@ -59,8 +59,7 @@ def get_existing_patch_numbers(base_date: str) -> list[int]:
 
 
 def get_version_from_metadata(specs_dir: Path, patch: int | None = None) -> str:
-    """
-    Get version from spec metadata with patch number.
+    """Get version from spec metadata with patch number.
 
     Version format: YYYY.MM.DD-PATCH
     - YYYY.MM.DD: Date when F5 published the specs (from Last-Modified header)
@@ -99,27 +98,26 @@ def get_version_from_git() -> str:
     try:
         # Try to get latest tag
         result = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=0"],
+            ["git", "describe", "--tags", "--abbrev=0"],  # noqa: S607
             capture_output=True,
             text=True,
             check=True,
         )
         tag = result.stdout.strip()
+    except subprocess.CalledProcessError:
+        # Generate version from date
+        return datetime.now(UTC).strftime("%Y.%m.%d")
+    else:
         if tag.startswith("v"):
             return tag[1:]
         return tag
-    except subprocess.CalledProcessError:
-        pass
-
-    # Generate version from date
-    return datetime.now(UTC).strftime("%Y.%m.%d")
 
 
 def get_git_sha() -> str:
     """Get current git commit SHA."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
             capture_output=True,
             text=True,
             check=True,
@@ -139,7 +137,8 @@ class ReleaseBuilder:
         original_specs_dir: Path | None = None,
         version: str | None = None,
         patch: int | None = None,
-    ):
+    ) -> None:
+        """Initialize ReleaseBuilder with paths and version info."""
         self.specs_dir = Path(specs_dir)
         self.output_dir = Path(output_dir)
         # Original specs dir contains the metadata from download
@@ -239,7 +238,7 @@ class ReleaseBuilder:
 
         for spec_file in domains_dir.glob("*.json"):
             try:
-                with open(spec_file) as f:
+                with spec_file.open() as f:
                     spec = json.load(f)
 
                 # Merge paths
@@ -252,10 +251,10 @@ class ReleaseBuilder:
                 console.print(f"[yellow]Could not merge {spec_file.name}: {e}[/yellow]")
 
         # Save merged specs
-        with open(staging_dir / "openapi.json", "w") as f:
+        with (staging_dir / "openapi.json").open("w") as f:
             json.dump(merged, f, indent=2)
 
-        with open(staging_dir / "openapi.yaml", "w") as f:
+        with (staging_dir / "openapi.yaml").open("w") as f:
             yaml.safe_dump(merged, f, default_flow_style=False, sort_keys=False)
 
         console.print(f"  [dim]Created: openapi.json ({len(merged['paths'])} paths)[/dim]")
@@ -279,7 +278,7 @@ class ReleaseBuilder:
 
 ## Version {self.version}
 
-Release date: {datetime.utcnow().strftime("%Y-%m-%d")}
+Release date: {datetime.now(UTC).strftime("%Y-%m-%d")}
 
 ### Changes
 
@@ -296,11 +295,10 @@ Release date: {datetime.utcnow().strftime("%Y-%m-%d")}
         ]
 
         for source in report_sources:
-            if source.exists():
-                if source.suffix == ".md":
-                    shutil.copy2(source, staging_dir / "VALIDATION_REPORT.md")
-                    console.print("  [dim]Added: VALIDATION_REPORT.md[/dim]")
-                    return
+            if source.exists() and source.suffix == ".md":
+                shutil.copy2(source, staging_dir / "VALIDATION_REPORT.md")
+                console.print("  [dim]Added: VALIDATION_REPORT.md[/dim]")
+                return
 
         # Generate placeholder report
         report_content = f"""# Validation Report
@@ -308,7 +306,7 @@ Release date: {datetime.utcnow().strftime("%Y-%m-%d")}
 ## Summary
 
 - **Version**: {self.version}
-- **Generated**: {datetime.utcnow().isoformat()}
+- **Generated**: {datetime.now(UTC).isoformat()}
 - **Status**: Validated
 
 See full validation details in the repository.
@@ -336,7 +334,7 @@ See full validation details in the repository.
                     }
                 )
 
-        with open(staging_dir / "manifest.json", "w") as f:
+        with (staging_dir / "manifest.json").open("w") as f:
             json.dump(manifest, f, indent=2)
 
         console.print("  [dim]Generated: manifest.json[/dim]")
@@ -394,7 +392,7 @@ See full validation details in the repository.
         return "\n".join(notes)
 
 
-def main():
+def main() -> int:
     """Main entry point for release command."""
     parser = argparse.ArgumentParser(description="Build release package for F5 XC fixed specs")
     parser.add_argument(
@@ -477,7 +475,7 @@ def main():
         print(builder.get_release_notes())
         return 0
 
-    zip_path = builder.build(
+    builder.build(
         include_changelog=not args.no_changelog,
         include_report=not args.no_report,
     )

--- a/scripts/spectral_lint.py
+++ b/scripts/spectral_lint.py
@@ -64,7 +64,8 @@ def map_violation_to_discrepancy(violation: dict[str, Any]) -> Discrepancy:
 class SpectralAdapter:
     """Run Spectral CLI and convert output to pipeline-compatible format."""
 
-    def __init__(self, ruleset: str = ".spectral.yaml"):
+    def __init__(self, ruleset: str = ".spectral.yaml") -> None:
+        """Initialize the Spectral adapter with a ruleset path."""
         self.ruleset = ruleset
 
     def run_lint(self, spec_dir: Path) -> list[dict[str, Any]]:
@@ -92,7 +93,7 @@ class SpectralAdapter:
         ]
 
         console.print(f"[dim]Running Spectral on {len(spec_files)} specs...[/dim]")
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
 
         if result.stdout.strip():
             return json.loads(result.stdout)
@@ -188,7 +189,7 @@ def main() -> int:
 
     config: dict[str, Any] = {}
     if args.config.exists():
-        with open(args.config) as f:
+        with args.config.open() as f:
             config = yaml.safe_load(f) or {}
 
     spectral_config = config.get("spectral", {})
@@ -211,19 +212,19 @@ def main() -> int:
         console.print(f"[bold]Spectral discover: {len(violations)} violations found[/bold]")
         return 0
 
-    else:  # gate
-        spec_dir = args.spec_dir or Path("release/specs")
-        output = args.output or Path("reports/spectral_gate_report.json")
-        gate_config = spectral_config.get("gate", {})
-        max_errors = gate_config.get("max_errors")
-        max_warnings = gate_config.get("max_warnings")
+    # gate mode
+    spec_dir = args.spec_dir or Path("release/specs")
+    output = args.output or Path("reports/spectral_gate_report.json")
+    gate_config = spectral_config.get("gate", {})
+    max_errors = gate_config.get("max_errors")
+    max_warnings = gate_config.get("max_warnings")
 
-        violations = adapter.run_lint(spec_dir)
-        adapter.write_report(violations, output)
+    violations = adapter.run_lint(spec_dir)
+    adapter.write_report(violations, output)
 
-        if adapter.check_gate(violations, max_errors, max_warnings) is False:
-            return 1
-        return 0
+    if adapter.check_gate(violations, max_errors, max_warnings) is False:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -6,9 +6,9 @@ from .report_generator import ReportGenerator
 from .spec_loader import SpecLoader
 
 __all__ = [
+    "ConstraintValidator",
     "F5XCAuth",
     "RateLimiter",
-    "SpecLoader",
-    "ConstraintValidator",
     "ReportGenerator",
+    "SpecLoader",
 ]

--- a/scripts/utils/auth.py
+++ b/scripts/utils/auth.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from typing import Any
 
 import httpx
 from rich.console import Console
 
 console = Console()
+
+# Rate limiting constants
+RATE_LIMIT_WINDOW_SECONDS = 60
+HTTP_TOO_MANY_REQUESTS = 429
+HTTP_OK = 200
+MIN_RPM = 5
 
 
 @dataclass
@@ -38,7 +46,8 @@ class RateLimitConfig:
 class RateLimiter:
     """Adaptive rate limiter with sliding window and exponential backoff."""
 
-    def __init__(self, config: RateLimitConfig | None = None):
+    def __init__(self, config: RateLimitConfig | None = None) -> None:
+        """Initialize RateLimiter with optional configuration."""
         self.config = config or RateLimitConfig()
         self._lock = threading.Lock()
         self._request_times: deque = deque(maxlen=100)
@@ -52,13 +61,13 @@ class RateLimiter:
             now = time.time()
 
             # Clean old entries (older than 60 seconds)
-            while self._request_times and now - self._request_times[0] > 60:
+            while self._request_times and now - self._request_times[0] > RATE_LIMIT_WINDOW_SECONDS:
                 self._request_times.popleft()
 
             # Check requests per minute
             if len(self._request_times) >= self._current_rpm:
                 oldest = self._request_times[0]
-                wait_time = 60 - (now - oldest) + 0.1
+                wait_time = RATE_LIMIT_WINDOW_SECONDS - (now - oldest) + 0.1
                 if wait_time > 0:
                     console.print(f"[yellow]Rate limit: waiting {wait_time:.1f}s[/yellow]")
                     time.sleep(wait_time)
@@ -101,7 +110,7 @@ class RateLimiter:
             # Decrease rate limit
             if self.config.adaptive:
                 self._current_rpm = max(
-                    5,  # Minimum 5 RPM
+                    MIN_RPM,
                     int(self._current_rpm * self.config.decrease_factor),
                 )
                 console.print(f"[red]Rate limit hit, reduced to {self._current_rpm} RPM[/red]")
@@ -144,11 +153,11 @@ class F5XCAuth:
     _rate_limiter: RateLimiter = field(default_factory=RateLimiter, init=False)
     _client: httpx.Client | None = field(default=None, init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
+        """Validate required fields after initialization."""
         if not self.api_token:
-            raise ValueError(
-                "F5XC_API_TOKEN environment variable not set. Please set it with your API token."
-            )
+            msg = "F5XC_API_TOKEN environment variable not set. Please set it with your API token."
+            raise ValueError(msg)
 
     @property
     def headers(self) -> dict[str, str]:
@@ -180,7 +189,7 @@ class F5XCAuth:
         self,
         method: str,
         path: str,
-        **kwargs,
+        **kwargs: Any,
     ) -> httpx.Response:
         """Make an authenticated request with rate limiting and retries."""
         last_exception = None
@@ -194,16 +203,14 @@ class F5XCAuth:
                 response = self.client.request(method, path, **kwargs)
 
                 # Check for rate limiting response
-                if response.status_code == 429:
+                if response.status_code == HTTP_TOO_MANY_REQUESTS:
                     backoff = self._rate_limiter.record_rate_limit()
 
                     # Check for Retry-After header
                     retry_after = response.headers.get("Retry-After")
                     if retry_after:
-                        try:
+                        with contextlib.suppress(ValueError):
                             backoff = max(backoff, float(retry_after))
-                        except ValueError:
-                            pass
 
                     console.print(
                         f"[yellow]Rate limited, backing off {backoff:.1f}s "
@@ -214,7 +221,7 @@ class F5XCAuth:
 
                 # Success
                 self._rate_limiter.record_success()
-                return response
+                return response  # noqa: TRY300
 
             except httpx.TimeoutException as e:
                 last_exception = e
@@ -230,19 +237,19 @@ class F5XCAuth:
 
         raise last_exception or RuntimeError("Request failed after all retries")
 
-    def get(self, path: str, **kwargs) -> httpx.Response:
+    def get(self, path: str, **kwargs: Any) -> httpx.Response:
         """Make a GET request."""
         return self.request("GET", path, **kwargs)
 
-    def post(self, path: str, **kwargs) -> httpx.Response:
+    def post(self, path: str, **kwargs: Any) -> httpx.Response:
         """Make a POST request."""
         return self.request("POST", path, **kwargs)
 
-    def put(self, path: str, **kwargs) -> httpx.Response:
+    def put(self, path: str, **kwargs: Any) -> httpx.Response:
         """Make a PUT request."""
         return self.request("PUT", path, **kwargs)
 
-    def delete(self, path: str, **kwargs) -> httpx.Response:
+    def delete(self, path: str, **kwargs: Any) -> httpx.Response:
         """Make a DELETE request."""
         return self.request("DELETE", path, **kwargs)
 
@@ -251,7 +258,7 @@ class F5XCAuth:
         try:
             # Use the web API namespaces endpoint to test
             response = self.get("/api/web/namespaces")
-            if response.status_code == 200:
+            if response.status_code == HTTP_OK:
                 # Verify our namespace exists
                 try:
                     data = response.json()
@@ -271,12 +278,12 @@ class F5XCAuth:
                     console.print("[green]API connection successful[/green]")
                 return True
             console.print(f"[red]API connection failed: {response.status_code}[/red]")
-            return False
+            return False  # noqa: TRY300
         except Exception as e:
             console.print(f"[red]API connection error: {e}[/red]")
             return False
 
-    def format_endpoint(self, template: str, **kwargs) -> str:
+    def format_endpoint(self, template: str, **kwargs: Any) -> str:
         """Format an endpoint template with namespace and other params."""
         return template.format(
             namespace=self.namespace,
@@ -284,10 +291,12 @@ class F5XCAuth:
             **kwargs,
         )
 
-    def __enter__(self):
+    def __enter__(self) -> F5XCAuth:
+        """Enter context manager."""
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
+        """Exit context manager and close client."""
         self.close()
 
 

--- a/scripts/utils/constraint_validator.py
+++ b/scripts/utils/constraint_validator.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 console = Console()
 
@@ -67,7 +69,8 @@ class ValidationTestCase:
 class ConstraintValidator:
     """Validate constraints and generate test cases."""
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize the constraint validator with test generators."""
         self._test_generators: dict[str, Callable] = {
             "minLength": self._generate_min_length_tests,
             "maxLength": self._generate_max_length_tests,
@@ -99,7 +102,7 @@ class ConstraintValidator:
     def _generate_min_length_tests(
         self,
         min_length: int,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for minLength constraint."""
         tests = []
@@ -151,7 +154,7 @@ class ConstraintValidator:
     def _generate_max_length_tests(
         self,
         max_length: int,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for maxLength constraint."""
         tests = []
@@ -201,7 +204,7 @@ class ConstraintValidator:
     def _generate_pattern_tests(
         self,
         pattern: str,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for pattern constraint."""
         tests = []
@@ -256,9 +259,9 @@ class ConstraintValidator:
 
         return samples
 
-    def _generate_non_matching_strings(self, pattern: str) -> list[str]:
+    def _generate_non_matching_strings(self, pattern: str) -> list[str]:  # noqa: ARG002
         """Generate strings that should NOT match a pattern."""
-        invalids = [
+        return [
             "123test",  # Starts with number (often invalid)
             "-test",  # Starts with hyphen
             "TEST_NAME",  # Uppercase and underscore
@@ -266,12 +269,11 @@ class ConstraintValidator:
             "",  # Empty
             "test!@#",  # Special characters
         ]
-        return invalids
 
     def _generate_minimum_tests(
         self,
         minimum: float,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for minimum constraint."""
         tests = []
@@ -311,7 +313,7 @@ class ConstraintValidator:
     def _generate_maximum_tests(
         self,
         maximum: float,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for maximum constraint."""
         tests = []
@@ -351,7 +353,7 @@ class ConstraintValidator:
     def _generate_exclusive_minimum_tests(
         self,
         exclusive_min: float,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for exclusiveMinimum constraint."""
         tests = []
@@ -381,7 +383,7 @@ class ConstraintValidator:
     def _generate_exclusive_maximum_tests(
         self,
         exclusive_max: float,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for exclusiveMaximum constraint."""
         tests = []
@@ -411,7 +413,7 @@ class ConstraintValidator:
     def _generate_min_items_tests(
         self,
         min_items: int,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for minItems constraint."""
         tests = []
@@ -453,7 +455,7 @@ class ConstraintValidator:
     def _generate_max_items_tests(
         self,
         max_items: int,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for maxItems constraint."""
         tests = []
@@ -493,7 +495,7 @@ class ConstraintValidator:
     def _generate_unique_items_tests(
         self,
         unique_items: bool,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for uniqueItems constraint."""
         tests = []
@@ -524,7 +526,7 @@ class ConstraintValidator:
     def _generate_enum_tests(
         self,
         enum_values: list,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for enum constraint."""
         tests = []
@@ -557,7 +559,7 @@ class ConstraintValidator:
     def _generate_type_tests(
         self,
         expected_type: str,
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for type constraint."""
         tests = []
@@ -601,23 +603,19 @@ class ConstraintValidator:
     def _generate_required_tests(
         self,
         required_fields: list[str],
-        schema: dict,
+        schema: dict,  # noqa: ARG002
     ) -> list[ValidationTestCase]:
         """Generate tests for required fields."""
-        tests = []
-
         # Test omitting each required field
-        for field_name in required_fields:
-            tests.append(
-                ValidationTestCase(
-                    name=f"required_missing_{field_name}",
-                    value={"_omit_field": field_name},
-                    expected_valid=False,
-                    description=f"Missing required field: {field_name}",
-                )
+        return [
+            ValidationTestCase(
+                name=f"required_missing_{field_name}",
+                value={"_omit_field": field_name},
+                expected_valid=False,
+                description=f"Missing required field: {field_name}",
             )
-
-        return tests
+            for field_name in required_fields
+        ]
 
     def compare_results(
         self,

--- a/scripts/utils/report_generator.py
+++ b/scripts/utils/report_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from jinja2 import BaseLoader, Environment
@@ -46,7 +46,8 @@ class ReportConfig:
 class ReportGenerator:
     """Generate validation reports in multiple formats."""
 
-    def __init__(self, config: ReportConfig):
+    def __init__(self, config: ReportConfig) -> None:
+        """Initialize ReportGenerator with config."""
         self.config = config
         self.config.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -88,7 +89,7 @@ class ReportGenerator:
             discrepancies_by_type[dtype] = discrepancies_by_type.get(dtype, 0) + 1
 
         return ValidationSummary(
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=datetime.now(UTC).isoformat(),
             total_endpoints=len(results),
             total_tests=sum(r.examples_tested for r in results),
             passed=sum(1 for r in results if r.status == TestStatus.PASSED),
@@ -115,7 +116,7 @@ class ReportGenerator:
             "discrepancies": [self._discrepancy_to_dict(d) for d in discrepancies],
         }
 
-        with open(output_path, "w") as f:
+        with output_path.open("w") as f:
             json.dump(report, f, indent=2, default=str)
 
         console.print(f"[green]JSON report: {output_path}[/green]")
@@ -130,7 +131,7 @@ class ReportGenerator:
         """Generate HTML report."""
         output_path = self.config.output_dir / "validation_report.html"
 
-        template = Environment(loader=BaseLoader()).from_string(HTML_TEMPLATE)
+        template = Environment(loader=BaseLoader(), autoescape=True).from_string(HTML_TEMPLATE)
 
         html = template.render(
             summary=summary,
@@ -140,7 +141,7 @@ class ReportGenerator:
             DiscrepancyType=DiscrepancyType,
         )
 
-        with open(output_path, "w") as f:
+        with output_path.open("w") as f:
             f.write(html)
 
         console.print(f"[green]HTML report: {output_path}[/green]")
@@ -173,8 +174,7 @@ class ReportGenerator:
             "",
         ]
 
-        for dtype, count in summary.discrepancies_by_type.items():
-            lines.append(f"- {dtype}: {count}")
+        lines.extend(f"- {dtype}: {count}" for dtype, count in summary.discrepancies_by_type.items())
 
         lines.extend(
             [
@@ -185,8 +185,7 @@ class ReportGenerator:
         )
 
         if summary.modified_files:
-            for f in summary.modified_files:
-                lines.append(f"- `{f}` (fixed)")
+            lines.extend(f"- `{f}` (fixed)" for f in summary.modified_files)
         else:
             lines.append("*No files required modification*")
 
@@ -199,8 +198,7 @@ class ReportGenerator:
         )
 
         if summary.unmodified_files:
-            for f in summary.unmodified_files:
-                lines.append(f"- `{f}`")
+            lines.extend(f"- `{f}`" for f in summary.unmodified_files)
         else:
             lines.append("*All files required modification*")
 
@@ -252,7 +250,7 @@ class ReportGenerator:
                 f"{r.examples_tested} | {len(r.discrepancies)} |"
             )
 
-        with open(output_path, "w") as f:
+        with output_path.open("w") as f:
             f.write("\n".join(lines))
 
         console.print(f"[green]Markdown report: {output_path}[/green]")

--- a/scripts/utils/schemathesis_runner.py
+++ b/scripts/utils/schemathesis_runner.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import schemathesis
 from hypothesis import Phase, Verbosity, settings
@@ -18,6 +21,10 @@ from .auth import F5XCAuth, RateLimiter
 from .constraint_validator import Discrepancy, DiscrepancyType
 
 console = Console()
+
+# HTTP status code thresholds
+HTTP_SERVER_ERROR = 500
+HTTP_CLIENT_ERROR = 400
 
 
 class TestStatus(Enum):
@@ -63,7 +70,8 @@ class SchemathesisRunner:
         self,
         auth: F5XCAuth,
         config: SchemathesisConfig | None = None,
-    ):
+    ) -> None:
+        """Initialize SchemathesisRunner with auth and config."""
         self.auth = auth
         self.config = config or SchemathesisConfig()
         self.results: list[SchemathesisResult] = []
@@ -107,9 +115,7 @@ class SchemathesisRunner:
             spec_copy["servers"] = [{"url": base_url}]
 
         # Create schema from dictionary (schemathesis 4.x API)
-        schema = schemathesis.openapi.from_dict(spec_copy)
-
-        return schema
+        return schemathesis.openapi.from_dict(spec_copy)
 
     def load_schema_from_file(
         self,
@@ -117,13 +123,11 @@ class SchemathesisRunner:
         base_url: str | None = None,
     ) -> Any:
         """Load OpenAPI schema from file."""
-        import json
-
         filepath = Path(filepath)
         base_url = base_url or self.auth.api_url
 
         # Load spec from file first
-        with open(filepath) as f:
+        with filepath.open() as f:
             spec = json.load(f)
 
         # Add base_url to servers field if not present
@@ -131,9 +135,7 @@ class SchemathesisRunner:
             spec["servers"] = [{"url": base_url}]
 
         # Load schema from dictionary (schemathesis 4.x API)
-        schema = schemathesis.openapi.from_dict(spec)
-
-        return schema
+        return schemathesis.openapi.from_dict(spec)
 
     def run_tests(
         self,
@@ -160,7 +162,7 @@ class SchemathesisRunner:
                     else:
                         # Not a Result object, use as-is
                         op = op_result
-                except Exception:
+                except Exception:  # noqa: S112
                     # Skip Err results
                     continue
 
@@ -217,7 +219,7 @@ class SchemathesisRunner:
                     response = self._execute_case(case)
 
                     # Check for failures
-                    if response.status_code >= 500:
+                    if response.status_code >= HTTP_SERVER_ERROR:
                         result.errors.append(
                             {
                                 "status_code": response.status_code,
@@ -344,21 +346,21 @@ class SchemathesisRunner:
                 # Can't validate - skip check
                 return None
 
-            if status_code not in responses:
-                # Check for default response
-                if "default" not in responses:
-                    # Unexpected status code - potential discrepancy
-                    if response.status_code >= 400:
-                        return Discrepancy(
-                            path=case.path,
-                            property_name="response",
-                            constraint_type="status_code",
-                            discrepancy_type=DiscrepancyType.CONSTRAINT_MISMATCH,
-                            spec_value=list(responses.keys()),
-                            api_behavior=status_code,
-                            test_values=[self._case_to_dict(case)],
-                            recommendation=f"Add {status_code} to response definitions",
-                        )
+            if (
+                status_code not in responses
+                and "default" not in responses
+                and response.status_code >= HTTP_CLIENT_ERROR
+            ):
+                return Discrepancy(
+                    path=case.path,
+                    property_name="response",
+                    constraint_type="status_code",
+                    discrepancy_type=DiscrepancyType.CONSTRAINT_MISMATCH,
+                    spec_value=list(responses.keys()),
+                    api_behavior=status_code,
+                    test_values=[self._case_to_dict(case)],
+                    recommendation=f"Add {status_code} to response definitions",
+                )
         except Exception:
             # If we can't get the response schema, skip validation
             return None
@@ -408,7 +410,7 @@ class SchemathesisRunner:
                     else:
                         # Not a Result object, use as-is
                         op = op_result
-                except Exception:
+                except Exception:  # noqa: S112
                     # This is an Err result or unwrapping failed - skip it
                     continue
 

--- a/scripts/utils/spec_loader.py
+++ b/scripts/utils/spec_loader.py
@@ -88,7 +88,8 @@ class SpecLoader:
         ]
     )
 
-    def __init__(self, spec_dir: Path | str):
+    def __init__(self, spec_dir: Path | str) -> None:
+        """Initialize SpecLoader with a spec directory path."""
         self.spec_dir = Path(spec_dir)
         self._specs: dict[str, dict] = {}
         self._schemas: dict[str, SchemaInfo] = {}
@@ -101,10 +102,11 @@ class SpecLoader:
             return self._specs[filename]
 
         if not filepath.exists():
-            raise FileNotFoundError(f"Spec file not found: {filepath}")
+            msg = f"Spec file not found: {filepath}"
+            raise FileNotFoundError(msg)
 
-        with open(filepath) as f:
-            if filename.endswith(".yaml") or filename.endswith(".yml"):
+        with filepath.open() as f:
+            if filename.endswith((".yaml", ".yml")):
                 spec = yaml.safe_load(f)
             else:
                 spec = json.load(f)
@@ -131,10 +133,11 @@ class SpecLoader:
         errors = []
         try:
             validate(spec)
-            return True, []
         except Exception as e:
             errors.append(str(e))
             return False, errors
+        else:
+            return True, []
 
     def extract_schemas(self, spec: dict) -> dict[str, SchemaInfo]:
         """Extract all schemas from an OpenAPI spec."""
@@ -327,19 +330,19 @@ class SpecLoader:
 def load_spec_from_file(filepath: Path | str) -> dict:
     """Convenience function to load a single spec file."""
     filepath = Path(filepath)
-    with open(filepath) as f:
+    with filepath.open() as f:
         if filepath.suffix in (".yaml", ".yml"):
             return yaml.safe_load(f)
         return json.load(f)
 
 
-def save_spec_to_file(spec: dict, filepath: Path | str, format: str = "json") -> None:
+def save_spec_to_file(spec: dict, filepath: Path | str, fmt: str = "json") -> None:
     """Save a spec to file in JSON or YAML format."""
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(filepath, "w") as f:
-        if format == "yaml":
+    with filepath.open("w") as f:
+        if fmt == "yaml":
             yaml.safe_dump(spec, f, default_flow_style=False, sort_keys=False)
         else:
             json.dump(spec, f, indent=2)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -29,7 +29,7 @@ def load_config(config_path: Path) -> dict:
         console.print(f"[red]Config file not found: {config_path}[/red]")
         sys.exit(1)
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         return yaml.safe_load(f)
 
 
@@ -39,7 +39,7 @@ def load_endpoints_config(config_path: Path) -> dict:
         console.print(f"[red]Endpoints config not found: {config_path}[/red]")
         sys.exit(1)
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         return yaml.safe_load(f)
 
 
@@ -52,7 +52,8 @@ class ValidationOrchestrator:
         endpoints_config: dict,
         auth: F5XCAuth | None = None,
         dry_run: bool = False,
-    ):
+    ) -> None:
+        """Initialize ValidationOrchestrator with config and auth."""
         self.config = config
         self.endpoints_config = endpoints_config
         self.dry_run = dry_run
@@ -101,7 +102,7 @@ class ValidationOrchestrator:
 
         # Step 2: Validate spec structure
         console.print("\n[bold]Step 2: Validating Spec Structure[/bold]")
-        spec_errors = self._validate_spec_structure(specs)
+        self._validate_spec_structure(specs)
 
         # Step 3: Extract constraints
         console.print("\n[bold]Step 3: Extracting Constraints[/bold]")
@@ -220,7 +221,7 @@ class ValidationOrchestrator:
 
         # Group specs by domain file
         domain_endpoints: dict[str, list] = {}
-        for endpoint_name, endpoint_config in endpoints_config.items():
+        for endpoint_config in endpoints_config.values():
             domain_file = endpoint_config.get("domain_file")
             if domain_file not in domain_endpoints:
                 domain_endpoints[domain_file] = []
@@ -286,7 +287,6 @@ class ValidationOrchestrator:
                     progress.update(task, advance=1)
                     continue
 
-                resource = endpoint_config.get("resource")
                 crud_ops = endpoint_config.get("crud_operations", {})
 
                 # Test create operation
@@ -302,8 +302,8 @@ class ValidationOrchestrator:
     def _test_endpoint_constraints(
         self,
         endpoint_name: str,
-        create_path: str,
-        test_cases: dict[str, list[ValidationTestCase]],
+        create_path: str,  # noqa: ARG002
+        test_cases: dict[str, list[ValidationTestCase]],  # noqa: ARG002
     ) -> None:
         """Test constraints for a specific endpoint."""
         # This would be implemented to actually test constraints
@@ -318,7 +318,7 @@ class ValidationOrchestrator:
 
         # For now, all files are considered unmodified until reconciliation
         specs = self.spec_loader.load_all_domain_files()
-        for filename in specs.keys():
+        for filename in specs:
             if any(d.path and filename in d.path for d in self.discrepancies):
                 modified_files.append(filename)
             else:
@@ -359,7 +359,7 @@ class ValidationOrchestrator:
             console.print(f"  Pass rate: {summary['pass_rate']:.1%}")
 
 
-def main():
+def main() -> int:
     """Main entry point for validation command."""
     parser = argparse.ArgumentParser(description="Validate F5 XC OpenAPI specs against live API")
     parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def sample_openapi_spec() -> dict:
 def sample_spec_file(temp_dir: Path, sample_openapi_spec: dict) -> Path:
     """Create a sample spec file."""
     spec_path = temp_dir / "test_spec.json"
-    with open(spec_path, "w") as f:
+    with spec_path.open("w") as f:
         json.dump(sample_openapi_spec, f)
     return spec_path
 
@@ -138,7 +138,7 @@ def sample_config() -> dict:
 def sample_config_file(temp_dir: Path, sample_config: dict) -> Path:
     """Create a sample config file."""
     config_path = temp_dir / "validation.yaml"
-    with open(config_path, "w") as f:
+    with config_path.open("w") as f:
         yaml.safe_dump(sample_config, f)
     return config_path
 

--- a/tests/test_spec_loader.py
+++ b/tests/test_spec_loader.py
@@ -18,7 +18,7 @@ class TestSpecLoader:
         """Create a spec loader with sample spec."""
         # Write sample spec to temp dir
         spec_path = temp_dir / "test.json"
-        with open(spec_path, "w") as f:
+        with spec_path.open("w") as f:
             json.dump(sample_openapi_spec, f)
 
         return SpecLoader(temp_dir)


### PR DESCRIPTION
## Summary

- Sync 10 governance config files from docs-control (.checkov.yaml, .codespellrc, .editorconfig-checker.json, .isort.cfg, .prettierignore, .python-lint, .ruff.toml, .textlintrc, .trivyignore, ruff.toml)
- Resolve all ruff lint violations across 14 Python source files introduced by the new ruff.toml with 40+ rule categories
- 18 ARG002 suppressions use `# noqa` for interface-contract method signatures with legitimately unused parameters (upstream issue #308 tracks adding ARG002 to the global ignore list)

Closes #103

## Changes by Category

### Governance Sync
Linter and tool configuration files distributed by docs-control governance.

### Ruff Compliance Fixes
| Rule | Description | Files |
|------|-------------|-------|
| PTH123 | Use `pathlib.Path.open()` instead of `open()` | 9 files |
| PLR2004 | Magic number constants extracted | 4 files |
| ANN204/ANN201/ANN003 | Return type and argument annotations | 3 files |
| D107 | Missing docstrings in `__init__` | 2 files |
| RET504/RET505 | Return statement simplification | 4 files |
| SIM102/SIM108 | Collapsible if / ternary expression | 1 file |
| DTZ003 | Timezone-aware `datetime.now()` | 2 files |
| S701 | Jinja2 autoescape | 1 file |
| PERF401 | List comprehension instead of append loop | 1 file |
| PLC0415 | Import at top of module | 1 file |
| ARG002 | Unused method argument (noqa suppression) | 3 files |
| TC003 | TYPE_CHECKING import | 1 file |
| F841 | Unused variable removal | 1 file |
| S603 | subprocess call (noqa suppression) | 1 file |

## Test plan

- [x] All 51 tests pass locally
- [x] `ruff check` reports zero errors
- [ ] CI checks pass