### PR TITLE
docs: comprehensive documentation overhaul for api-specs pipeline

### DIFF
--- a/docs/02-pipeline.mdx
+++ b/docs/02-pipeline.mdx
@@ -1,0 +1,80 @@
+---
+title: Pipeline Overview
+description: Six-stage automated pipeline that downloads, validates, lints, reconciles, gates, and releases F5 XC OpenAPI specs
+---
+
+The pipeline runs daily at 6 AM UTC via GitHub Actions (`validate-and-release.yml`) and on every push to `main` that touches `scripts/`, `config/`, or `pyproject.toml`. It can also be triggered manually with options to force a release or skip live API tests.
+
+## Pipeline Stages
+
+```
+ Download         Validate          Spectral Lint
+ ┌──────┐        ┌──────────┐      ┌─────────────┐
+ │ Fetch │───────▶│Schemathesis│────▶│  Discover   │
+ │ specs │        │Constraints│     │  violations │
+ └──────┘        └──────────┘      └─────────────┘
+                                          │
+                 Spectral Gate       Reconcile
+                ┌─────────────┐    ┌──────────┐
+                │  Enforce    │◀───│Apply fixes│
+                │  thresholds │    │to specs   │
+                └─────────────┘    └──────────┘
+                       │
+                    Release
+                 ┌──────────┐
+                 │  Package  │
+                 │  & tag    │
+                 └──────────┘
+```
+
+### 1. Download
+
+`scripts/download.py` fetches the official F5 XC OpenAPI spec ZIP from `docs.cloud.f5.com`. It uses HTTP ETag headers for conditional GET requests -- if the upstream bundle has not changed, the download is skipped. Extracted JSON specs land in `specs/original/`.
+
+### 2. Validate
+
+`scripts/validate.py` orchestrates two kinds of testing against the live F5 XC API:
+
+- **Schemathesis** -- property-based testing that generates random valid/invalid payloads per the spec and checks whether the API agrees with the spec's constraints.
+- **Constraint validation** -- targeted tests for all 10 OpenAPI constraint categories (string length, pattern, numeric bounds, required fields, enums, array bounds, object structure, composition, dependencies, data types).
+
+Discrepancies are written to `reports/validation_report.json`.
+
+### 3. Spectral Lint (Discover)
+
+`scripts/spectral_lint.py --mode discover` runs the Spectral CLI against the original specs using `spectral-pipeline.yaml`. This finds OAS3 quality issues -- missing servers blocks, missing contact info, untagged operations, unused component schemas, duplicate operationIds, invalid examples, and script tags in descriptions.
+
+Violations are converted to `Discrepancy` objects and written to `reports/spectral_report.json`. See [Spectral Rules](/04-spectral-rules/) for the full rule set.
+
+### 4. Reconcile
+
+`scripts/reconcile.py` consumes both report files and applies fixes to every spec:
+
+- **Constraint fixes** adjust schema constraints (relax, tighten, add, remove) based on observed API behavior. See [Fixes Applied](/03-fixes-applied/).
+- **Spectral fixes** enrich specs with servers, contact info, tags, security metadata, and remove dead components.
+- **Security metadata** is always injected if the `security_scheme` config is present, even when Spectral did not flag it.
+
+Fixed specs are written to `release/specs/` and validated with `openapi-spec-validator` before saving. If a fixed spec fails validation, the original is used as a fallback.
+
+### 5. Spectral Gate
+
+`scripts/spectral_lint.py --mode gate` re-runs Spectral against the reconciled specs in `release/specs/`. The gate checks error and warning counts against configurable thresholds (`spectral.gate.max_errors` and `spectral.gate.max_warnings` in `validation.yaml`).
+
+:::note
+Phase 1 (current): thresholds are `null` (warn-only). Set `max_errors: 0` to enforce a zero-error gate.
+:::
+
+### 6. Release
+
+`scripts/release.py` packages the reconciled specs into a versioned ZIP archive. Versions use the format `YYYY.MM.DD-<patch>` derived from the upstream spec metadata date. The release includes:
+
+- Individual domain spec files (268 JSON files)
+- A merged `openapi.json` combining all domains
+- A `CHANGELOG.md` listing every fix applied
+- A `VALIDATION_REPORT.md` summary
+
+The CI job creates a GitHub Release with the ZIP attached, tagged `v<version>`. A content hash prevents duplicate releases when nothing has changed.
+
+## Documentation Update
+
+A parallel CI job generates `docs/01-validation-report.mdx` from the validation reports using `scripts/generate_docs.py`, then opens a PR if the content changed.

--- a/docs/03-fixes-applied.mdx
+++ b/docs/03-fixes-applied.mdx
@@ -1,0 +1,158 @@
+---
+title: Fixes Applied to Upstream Specs
+description: Complete reference of every fix the reconciliation engine applies to F5 XC OpenAPI specifications
+---
+
+The reconciler (`scripts/reconcile.py`) applies four categories of fixes to upstream specs. Constraint fixes change API contracts to match observed behavior. All other fixes are metadata-only and do not alter API contracts.
+
+## Constraint Fixes
+
+These fixes adjust OpenAPI schema constraints so the spec matches what the live API actually enforces. Each fix is driven by a `Discrepancy` object produced during [validation](/02-pipeline/#2-validate).
+
+| Strategy | Trigger | What It Does | Contract Change |
+|----------|---------|--------------|-----------------|
+| **Relax** | `SPEC_STRICTER` | Spec rejects values the API accepts. Lowers `minLength`/`minimum`, raises `maxLength`/`maximum`, adds missing enum values. | Yes -- widens accepted values |
+| **Tighten** | `SPEC_LOOSER` | Spec accepts values the API rejects. Raises `minLength`/`minimum`, lowers `maxLength`/`maximum`, restricts enums to observed values. | Yes -- narrows accepted values |
+| **Add** | `MISSING_CONSTRAINT` | API enforces a constraint not documented in the spec. Adds the constraint to the schema. | Yes -- adds new constraint |
+| **Remove** | `EXTRA_CONSTRAINT` | Spec declares a constraint the API ignores. Removes the constraint from the schema. | Yes -- removes constraint |
+
+:::caution
+Constraint fixes change the API contract. They are only applied when backed by evidence from Schemathesis or constraint validation testing against the live API.
+:::
+
+### Supported Constraint Types
+
+The 10 OpenAPI constraint categories tested and fixed:
+
+- **String length** -- `minLength`, `maxLength`
+- **Pattern** -- `pattern` (regex)
+- **Numeric bounds** -- `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`
+- **Required fields** -- `required`
+- **Enum values** -- `enum`
+- **Array bounds** -- `minItems`, `maxItems`, `uniqueItems`
+- **Object structure** -- `additionalProperties`, `properties`, `propertyNames`
+- **Composition** -- `oneOf`, `anyOf`, `allOf`
+- **Dependencies** -- `dependentRequired`, `dependentSchemas`
+- **Data types** -- `type`, `format`
+
+## Spectral Enrichments
+
+These fixes address OAS3 quality issues found by [Spectral linting](/04-spectral-rules/). They add or correct metadata without changing API behavior.
+
+### Servers Block Injection
+
+**Rule**: `oas3-api-servers` | **Contract change**: No
+
+Adds the F5 XC tenant URL template to specs missing a `servers` block:
+
+```json
+"servers": [{
+  "url": "https://{tenant}.console.ves.volterra.io",
+  "description": "F5 Distributed Cloud API",
+  "variables": {
+    "tenant": {
+      "default": "f5-amer-ent",
+      "description": "Your F5 XC tenant name"
+    }
+  }
+}]
+```
+
+The server URL and variable values come from `spectral.servers` in [validation.yaml](/05-configuration/).
+
+### Contact Info Injection
+
+**Rule**: `info-contact` | **Contract change**: No
+
+Adds contact information to `info.contact` for specs missing it:
+
+```json
+"contact": {
+  "name": "F5 Distributed Cloud",
+  "url": "https://docs.cloud.f5.com",
+  "email": "support@f5.com"
+}
+```
+
+Values come from `spectral.contact` in [validation.yaml](/05-configuration/).
+
+### Operation Tag Derivation
+
+**Rule**: `operation-tags` | **Contract change**: No
+
+Derives a tag from the URL path prefix for untagged operations. For a path like `/api/config/namespaces/{namespace}/healthchecks`, the tag is `config` (the second non-parameter segment). The tag is added to both the operation's `tags` array and the spec-level `tags` list.
+
+### Unused Component Removal
+
+**Rule**: `oas3-unused-component` | **Contract change**: No
+
+Removes component schemas from `components.schemas` that are not referenced anywhere in the spec. Reduces spec size without affecting any operation.
+
+### OperationId Deduplication
+
+**Rule**: `operation-operationId-unique` | **Contract change**: No
+
+Appends the HTTP method as a suffix (e.g., `ListItems_get`) when multiple operations share the same `operationId`. This makes each operationId unique for code generators.
+
+### Invalid Example/Default Removal
+
+**Rule**: `oas3-valid-schema-example` | **Contract change**: No
+
+Removes `example` or `default` values from schemas when the value does not conform to the schema's own constraints (wrong type, out of range, etc.). Prevents code generators from producing invalid sample payloads.
+
+### Script Tag Stripping
+
+**Rule**: `no-script-tags-in-markdown` | **Contract change**: No
+
+Strips `<script>` tags from `description` fields using a regex replacement. Some upstream specs contain injected script tags that break documentation renderers.
+
+## Security Metadata
+
+**Contract change**: No (documentation-only)
+
+Every spec receives an `apiKeyAuth` security scheme if one is not already present. This is always injected regardless of whether Spectral flagged it.
+
+```json
+"components": {
+  "securitySchemes": {
+    "apiKeyAuth": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "Authorization",
+      "description": "F5 XC API Token (format: APIToken <token>)"
+    }
+  }
+},
+"security": [{ "apiKeyAuth": [] }]
+```
+
+The scheme definition comes from `spectral.security_scheme` in [validation.yaml](/05-configuration/). This tells API consumers how to authenticate but does not change runtime behavior.
+
+## JSON Formatting
+
+**Contract change**: No
+
+All output JSON specs pass through a Biome-compatible array compactor (`_compact_short_arrays` in `scripts/utils/spec_loader.py`). Short arrays that fit within 120 characters are collapsed to a single line:
+
+```json
+// Before
+"enum": [
+  "ACTIVE",
+  "INACTIVE"
+]
+
+// After
+"enum": ["ACTIVE", "INACTIVE"]
+```
+
+Arrays exceeding the line-length threshold remain multi-line.
+
+## Fix Priority
+
+When multiple fix strategies could apply, the reconciler uses a priority order configured in `reconciliation.priority`:
+
+1. **existing** -- Use the existing spec constraint if it is valid
+2. **discovery** -- Use the discovered live API behavior
+3. **inferred** -- Infer from patterns across similar endpoints
+
+Every fixed spec is validated with `openapi-spec-validator` after all fixes are applied. If validation fails, the original spec is used as a fallback and the fix is logged as an error.

--- a/docs/04-spectral-rules.mdx
+++ b/docs/04-spectral-rules.mdx
@@ -1,0 +1,122 @@
+---
+title: Spectral Linting Rules
+description: Two-config Spectral architecture with base OAS rules and a custom f5-path-params function
+---
+
+The project uses [Spectral](https://stoplight.io/open-source/spectral) for OAS3 linting with a two-config architecture that separates CI/external tooling from the pipeline's custom logic.
+
+## Two-Config Architecture
+
+### `.spectral.yaml` -- Base Config
+
+Used by GitHub Super-Linter and any external CI tool. Extends `spectral:oas` (the built-in OAS ruleset). Contains no custom functions -- this keeps it compatible with tools that run Spectral without access to the `spectral/functions/` directory.
+
+```yaml
+extends:
+  - "spectral:oas"
+
+rules:
+  path-params: "off"
+  operation-tags: warn
+  oas3-api-servers: warn
+  info-contact: warn
+  oas3-unused-component: warn
+  operation-operationId-unique: error
+  oas3-valid-schema-example: error
+  no-script-tags-in-markdown: warn
+  operation-description: info
+  info-description: info
+```
+
+### `spectral-pipeline.yaml` -- Pipeline Config
+
+Used by `scripts/spectral_lint.py` (both discover and gate modes). Extends the base config and adds the custom `f5-path-params` function:
+
+```yaml
+extends:
+  - "./.spectral.yaml"
+
+functionsDir: "./spectral/functions"
+functions:
+  - f5-path-params
+
+rules:
+  f5-path-params:
+    description: "Path parameters must be declared and used"
+    message: "{{error}}"
+    severity: error
+    given: "$.paths[*]"
+    then:
+      function: f5-path-params
+```
+
+## Why `path-params` Is Disabled
+
+Spectral's built-in `path-params` rule incorrectly flags F5 XC APIs that use dotted parameter names like `{metadata.namespace}` and `{metadata.name}`. The built-in rule does not parse dots in parameter names, so it reports them as undeclared.
+
+The custom `f5-path-params` function (`spectral/functions/f5-path-params.js`) correctly handles dotted names by matching the full `{placeholder}` content against declared parameter names. It checks both path-level and operation-level parameters, and reports errors in both directions:
+
+- A placeholder in the URL path that has no matching parameter declaration
+- A declared path parameter that does not appear in the URL path
+
+## Rule Reference
+
+### Auto-Fixable Rules
+
+These rules are auto-fixed by the reconciler when violations are detected. See [Fixes Applied](/03-fixes-applied/) for details on each fix.
+
+| Rule | Severity | Fix Method | Description |
+|------|----------|------------|-------------|
+| `oas3-api-servers` | warn | `_add_servers` | Spec must have a `servers` block |
+| `info-contact` | warn | `_add_contact` | `info` must include `contact` |
+| `operation-tags` | warn | `_add_tags` | Every operation must have at least one tag |
+| `oas3-unused-component` | warn | `_remove_unused_component` | No unreferenced component schemas |
+| `operation-operationId-unique` | error | `_deduplicate_operation_id` | All operationIds must be unique |
+| `oas3-valid-schema-example` | error | `_fix_schema_example` | Examples/defaults must match their schema |
+| `no-script-tags-in-markdown` | warn | `_strip_script_tags` | No `<script>` tags in descriptions |
+| `f5-path-params` | error | -- | Path parameters must be declared and used |
+
+:::note
+`f5-path-params` is an error-severity rule but is not auto-fixed. Violations indicate a genuine spec defect that requires manual review.
+:::
+
+### Non-Fixable Rules
+
+These rules are downgraded to `info` severity because they cannot be auto-fixed meaningfully:
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `operation-description` | info | Operations should have a description |
+| `info-description` | info | API info should have a description |
+
+## Pipeline Integration
+
+The Spectral adapter (`scripts/spectral_lint.py`) runs in two modes:
+
+### Discover Mode (Pre-Reconcile)
+
+```bash
+make spectral-lint
+# Equivalent to: python -m scripts.spectral_lint --mode discover
+```
+
+Scans `specs/original/` and writes `reports/spectral_report.json`. The reconciler consumes this report alongside the validation report.
+
+### Gate Mode (Post-Reconcile)
+
+```bash
+make spectral-gate
+# Equivalent to: python -m scripts.spectral_lint --mode gate
+```
+
+Scans `release/specs/` and writes `reports/spectral_gate_report.json`. Returns exit code 1 if violations exceed the configured thresholds.
+
+### Violation Mapping
+
+Spectral violations are converted to `Discrepancy` objects with three subtypes:
+
+| Spectral Rule Category | DiscrepancyType | Example Rules |
+|------------------------|-----------------|---------------|
+| Missing required element | `SPECTRAL_MISSING` | `oas3-api-servers`, `info-contact`, `operation-tags` |
+| Invalid existing element | `SPECTRAL_INVALID` | `oas3-valid-schema-example`, `no-script-tags-in-markdown` |
+| Dead code | `SPECTRAL_UNUSED` | `oas3-unused-component` |

--- a/docs/05-configuration.mdx
+++ b/docs/05-configuration.mdx
@@ -1,0 +1,251 @@
+---
+title: Configuration Reference
+description: Reference for validation.yaml and endpoints.yaml configuration files
+---
+
+All pipeline behavior is controlled by two YAML files in `config/`.
+
+## `config/validation.yaml`
+
+### API Settings
+
+```yaml
+api:
+  base_url: "https://f5-amer-ent.console.ves.volterra.io"
+  tenant: "f5-amer-ent"
+  namespace: "r-mordasiewicz"
+  timeout: 30
+  retries: 3
+  retry_delay: 2
+```
+
+| Field | Description |
+|-------|-------------|
+| `base_url` | F5 XC console API base URL. Override with `F5XC_API_URL` env var. |
+| `tenant` | Tenant name used in API paths. |
+| `namespace` | Default namespace for CRUD operations. |
+| `timeout` | HTTP request timeout in seconds. |
+| `retries` | Number of retry attempts on failure. |
+| `retry_delay` | Seconds between retries. |
+
+### Download Settings
+
+```yaml
+download:
+  url: "https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
+  output_dir: "specs/original"
+  etag_cache: ".etag_cache"
+```
+
+| Field | Description |
+|-------|-------------|
+| `url` | URL of the official F5 XC OpenAPI spec bundle (ZIP). |
+| `output_dir` | Where extracted specs are stored. |
+| `etag_cache` | File that stores the HTTP ETag for conditional downloads. |
+
+### Validation Categories
+
+Ten categories corresponding to the OpenAPI schema constraint types. Each can be independently enabled/disabled.
+
+```yaml
+validation_categories:
+  string_length:
+    enabled: true
+    keywords: ["minLength", "maxLength"]
+    description: "Validate string length boundaries"
+```
+
+| Category | Keywords |
+|----------|----------|
+| `string_length` | `minLength`, `maxLength` |
+| `pattern` | `pattern` |
+| `numeric_bounds` | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum` |
+| `required_fields` | `required` |
+| `enum_values` | `enum` |
+| `array_bounds` | `minItems`, `maxItems`, `uniqueItems` |
+| `object_structure` | `additionalProperties`, `properties`, `propertyNames` |
+| `composition` | `oneOf`, `anyOf`, `allOf` |
+| `dependencies` | `dependentRequired`, `dependentSchemas` |
+| `data_types` | `type`, `format` |
+
+### Schemathesis Settings
+
+```yaml
+schemathesis:
+  enabled: true
+  max_examples: 100
+  hypothesis_phases:
+    - generate
+    - target
+  stateful_testing: true
+  base_url_override: null
+  auth_header: "Authorization"
+  auth_prefix: "APIToken"
+```
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Toggle Schemathesis testing. |
+| `max_examples` | Maximum number of generated test cases per operation. |
+| `hypothesis_phases` | Hypothesis phases to run (`generate`, `target`). |
+| `stateful_testing` | Enable stateful link-based testing across operations. |
+| `base_url_override` | Override the API base URL for tests. `null` uses `api.base_url`. |
+| `auth_header` | HTTP header name for authentication. |
+| `auth_prefix` | Token prefix format (requests are sent as `APIToken <token>`). |
+
+### Reconciliation Settings
+
+```yaml
+reconciliation:
+  priority:
+    - existing
+    - discovery
+    - inferred
+  fix_strategies:
+    tighter_spec: "relax"
+    looser_spec: "tighten"
+    missing_constraint: "add"
+    extra_constraint: "remove"
+```
+
+| Field | Description |
+|-------|-------------|
+| `priority` | Order of preference when multiple data sources disagree. |
+| `fix_strategies` | Maps each discrepancy type to its fix action. See [Fixes Applied](/03-fixes-applied/). |
+
+### Spectral Settings
+
+```yaml
+spectral:
+  enabled: true
+  ruleset: "spectral-pipeline.yaml"
+  auto_fix:
+    oas3-api-servers: true
+    info-contact: true
+    operation-tags: true
+    oas3-unused-component: true
+    operation-operationId-unique: true
+    oas3-valid-schema-example: true
+    no-script-tags-in-markdown: true
+  gate:
+    max_errors: null
+    max_warnings: null
+  contact:
+    name: "F5 Distributed Cloud"
+    url: "https://docs.cloud.f5.com"
+    email: "support@f5.com"
+  servers:
+    - url: "https://{tenant}.console.ves.volterra.io"
+      description: "F5 Distributed Cloud API"
+      variables:
+        tenant:
+          default: "f5-amer-ent"
+          description: "Your F5 XC tenant name"
+  security_scheme:
+    type: "apiKey"
+    in: "header"
+    name: "Authorization"
+    description: "F5 XC API Token (format: APIToken <token>)"
+```
+
+| Field | Description |
+|-------|-------------|
+| `enabled` | Toggle Spectral linting entirely. |
+| `ruleset` | Which Spectral config file to use (pipeline uses `spectral-pipeline.yaml`). |
+| `auto_fix` | Map of rule name to boolean. `true` means the reconciler will fix violations. |
+| `gate.max_errors` | Maximum allowed errors in the post-reconcile gate. `null` disables the check. |
+| `gate.max_warnings` | Maximum allowed warnings. `null` disables the check. |
+| `contact` | Contact info injected into `info.contact` by the `info-contact` fixer. |
+| `servers` | Servers array injected by the `oas3-api-servers` fixer. |
+| `security_scheme` | Security scheme definition injected into every spec. |
+
+### Report Settings
+
+```yaml
+reports:
+  output_dir: "reports"
+  formats:
+    - json
+    - html
+    - markdown
+  include_examples: true
+  max_examples_per_issue: 5
+```
+
+### Release Settings
+
+```yaml
+release:
+  output_dir: "release"
+  include_changelog: true
+  include_validation_report: true
+  version_from: "git"
+```
+
+| Field | Description |
+|-------|-------------|
+| `output_dir` | Directory for release artifacts. |
+| `include_changelog` | Include `CHANGELOG.md` in the release package. |
+| `include_validation_report` | Include the validation report in the release package. |
+| `version_from` | Version source. `git` derives version from spec metadata date + patch number. |
+
+## `config/endpoints.yaml`
+
+Defines the baseline endpoints used for live API validation. Each entry maps a logical resource name to its spec file, API group, and CRUD paths.
+
+### Endpoint Structure
+
+```yaml
+endpoints:
+  healthcheck:
+    resource: healthchecks
+    domain_file: docs-cloud-f5-com.0124.public.ves.io.schema.healthcheck.ves-swagger.json
+    api_group: config
+    crud_operations:
+      create: POST /api/config/namespaces/{namespace}/healthchecks
+      read: GET /api/config/namespaces/{namespace}/healthchecks/{name}
+      list: GET /api/config/namespaces/{namespace}/healthchecks
+      update: PUT /api/config/namespaces/{namespace}/healthchecks/{name}
+      delete: DELETE /api/config/namespaces/{namespace}/healthchecks/{name}
+    test_priority: high
+    description: "Health check configurations for origin monitoring"
+```
+
+| Field | Description |
+|-------|-------------|
+| `resource` | API resource name (used in URL paths). |
+| `domain_file` | Filename of the OpenAPI spec in `specs/original/`. |
+| `api_group` | API group prefix (`config`, `web`, etc.). |
+| `crud_operations` | HTTP method and path for each CRUD operation. |
+| `test_priority` | `high`, `medium`, or `low` -- controls test execution order. |
+| `description` | Human-readable description of the resource. |
+
+### Current Baseline Endpoints
+
+10 endpoints across three domains:
+
+| Endpoint | Domain | Priority |
+|----------|--------|----------|
+| `healthcheck` | Virtual | high |
+| `origin_pool` | Virtual | high |
+| `app_firewall` | Virtual | high |
+| `service_policy` | Virtual | medium |
+| `api_definition` | API Security | high |
+| `api_discovery` | API Security | medium |
+| `api_groups` | API Security | medium |
+| `code_base_integration` | API Security | low |
+| `data_type` | Data Privacy | medium |
+| `sensitive_data_policy` | Data Privacy | medium |
+
+### Adding New Endpoints
+
+To add a new endpoint for validation:
+
+1. Find the spec filename in `specs/original/` (format: `docs-cloud-f5-com.NNNN.*.ves-swagger.json`)
+2. Add an entry under `endpoints:` following the structure above
+3. Add the domain file mapping under `domain_files:` with a priority number
+4. Add the endpoint name to `test_order:` in the desired position
+
+:::tip
+The framework validates all 268 specs during reconciliation regardless of what is listed in `endpoints.yaml`. The endpoints config controls which resources get live API testing with Schemathesis.
+:::

--- a/docs/06-contributing.mdx
+++ b/docs/06-contributing.mdx
@@ -1,0 +1,191 @@
+---
+title: Development Guide
+description: How to set up, run, test, and contribute to the F5 XC API Specs project
+---
+
+## Setup
+
+```bash
+# Clone and install dev dependencies
+git clone https://github.com/f5xc-salesdemos/api-specs.git
+cd api-specs
+make dev-install
+
+# Install Spectral CLI (required for linting stages)
+npm install -g @stoplight/spectral-cli
+```
+
+`make dev-install` creates a virtualenv in `.venv/` and installs the project with dev extras (pytest, ruff, mypy).
+
+### Environment Variables
+
+Live API validation requires:
+
+```bash
+export F5XC_API_URL="https://f5-amer-ent.console.ves.volterra.io"
+export F5XC_API_TOKEN="your-api-token"
+```
+
+Without these, `make validate` falls back to dry-run mode.
+
+## Running the Pipeline
+
+### Full Pipeline
+
+```bash
+make all
+# Runs: download → validate → spectral-lint → reconcile → spectral-gate → release
+```
+
+### Individual Stages
+
+```bash
+make download        # Fetch upstream specs
+make validate        # Run live API tests (requires API token)
+make validate-dry    # Dry run (no API calls)
+make spectral-lint   # Spectral discover mode on original specs
+make reconcile       # Apply fixes from both reports
+make spectral-gate   # Spectral quality gate on reconciled specs
+make release         # Build release package
+```
+
+### Documentation
+
+```bash
+make docs-generate   # Regenerate docs/01-validation-report.mdx from reports
+make docs            # Build full documentation site
+make docs-serve      # Local dev server with hot reload
+```
+
+## Running Tests
+
+```bash
+make test           # pytest with coverage
+make lint           # ruff check + format check
+make typecheck      # mypy type checking
+make ci-test        # All three (used in CI)
+```
+
+Pre-commit hooks run automatically on commit if installed:
+
+```bash
+make pre-commit-install   # Install git hooks
+make pre-commit           # Run all hooks manually
+```
+
+## Project Structure
+
+```
+scripts/
+  download.py           # Stage 1: Fetch specs from F5
+  validate.py           # Stage 2: Live API testing
+  spectral_lint.py      # Stage 3/5: Spectral linting adapter
+  reconcile.py          # Stage 4: Apply fixes to specs
+  release.py            # Stage 6: Package release
+  generate_docs.py      # Generate MDX from reports
+  utils/
+    auth.py             # F5 XC API authentication
+    constraint_validator.py  # Constraint testing + Discrepancy types
+    report_generator.py      # Report formatting
+    schemathesis_runner.py   # Schemathesis test orchestration
+    spec_loader.py           # Spec I/O + JSON formatting
+
+config/
+  validation.yaml       # Pipeline configuration
+  endpoints.yaml        # Baseline endpoints for live testing
+
+spectral/
+  functions/
+    f5-path-params.js   # Custom Spectral function
+
+docs/                   # Starlight MDX documentation
+tests/                  # pytest test suite
+release/specs/          # Output: reconciled spec files
+reports/                # Output: validation and Spectral reports
+```
+
+## Adding a New Fix Method
+
+To add a new Spectral auto-fix to the reconciler:
+
+1. **Add the rule** to `.spectral.yaml` with the desired severity.
+
+2. **Enable auto-fix** in `config/validation.yaml` under `spectral.auto_fix`:
+   ```yaml
+   spectral:
+     auto_fix:
+       your-new-rule: true
+   ```
+
+3. **Add the fixer method** to `SpecReconciler` in `scripts/reconcile.py`:
+   ```python
+   def _fix_your_rule(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
+       """Fix description."""
+       # Modify spec in place
+       # Return spec if changed, None if no change needed
+       return spec
+   ```
+
+4. **Register it** in the `_apply_spectral_fix` dispatcher:
+   ```python
+   spectral_fixers = {
+       # ... existing fixers ...
+       "spectral:your-new-rule": self._fix_your_rule,
+   }
+   ```
+
+5. **Add tests** covering the new fix method.
+
+## Adding a New Spectral Rule
+
+To add a custom Spectral rule with a JavaScript function:
+
+1. Create the function in `spectral/functions/your-rule.js`. Export a default function that receives `(targetVal, options, context)` and returns an array of `{message, path}` objects.
+
+2. Register it in `spectral-pipeline.yaml`:
+   ```yaml
+   functions:
+     - f5-path-params
+     - your-rule
+
+   rules:
+     your-rule:
+       description: "What it checks"
+       message: "{{error}}"
+       severity: error
+       given: "$.paths[*]"
+       then:
+         function: your-rule
+   ```
+
+:::caution
+Custom functions only work in `spectral-pipeline.yaml`. Do not add `functionsDir` or `functions` to `.spectral.yaml` -- that config must remain compatible with Super-Linter and other external tools.
+:::
+
+## CI Pipeline
+
+The GitHub Actions workflow (`validate-and-release.yml`) runs on:
+
+- **Schedule**: Daily at 6 AM UTC
+- **Push to main**: When `scripts/`, `config/`, or `pyproject.toml` changes
+- **Manual dispatch**: With options for forced release or dry-run
+
+The workflow has four jobs:
+
+1. **validate** -- Downloads specs, runs validation, Spectral lint, reconcile, Spectral gate
+2. **check-release-needed** -- Compares content hashes to decide if a release is warranted
+3. **release** -- Packages and creates a GitHub Release (only if content changed)
+4. **update-docs** -- Regenerates `01-validation-report.mdx` and opens a PR if changed
+
+A **notify** job creates a GitHub issue if any job fails.
+
+## Branch and PR Workflow
+
+All changes follow: **Issue -> Branch -> PR -> CI passes -> Merge**.
+
+- Branch names: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`
+- PRs must link an issue (`Closes #N` in the description)
+- Required CI checks: `Check linked issues` and `Lint Code Base`
+- Squash merge preferred; branches auto-delete after merge
+
+See `CONTRIBUTING.md` for the complete workflow rules.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,14 +1,46 @@
 ---
-title: API Specs
-description: Validated and reconciled F5 Distributed Cloud OpenAPI specifications
+title: F5 XC API Specs
+description: Validated, enriched, and OAS3-compliant OpenAPI specifications for F5 Distributed Cloud
 template: splash
 sidebar:
   hidden: true
 hero:
-  tagline: Validated and reconciled F5 Distributed Cloud OpenAPI specifications
+  tagline: Production-ready OpenAPI specs for F5 Distributed Cloud — validated against the live API, auto-repaired, and enriched with security metadata, server definitions, and operation tags.
   actions:
-    - text: View Report
-      link: 01-validation-report/
+    - text: Pipeline Overview
+      link: 02-pipeline/
       icon: right-arrow
       variant: primary
+    - text: View Latest Report
+      link: 01-validation-report/
+      variant: secondary
 ---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <Card title="Pipeline Overview" icon="rocket">
+    Six-stage automated pipeline: download, validate, lint, reconcile, gate, release.
+    [Read more](/02-pipeline/)
+  </Card>
+  <Card title="Fixes Applied" icon="pencil">
+    Constraint repairs, Spectral enrichments, security metadata, and JSON formatting.
+    [Read more](/03-fixes-applied/)
+  </Card>
+  <Card title="Spectral Rules" icon="warning">
+    Two-config linting architecture with a custom `f5-path-params` function.
+    [Read more](/04-spectral-rules/)
+  </Card>
+  <Card title="Configuration" icon="setting">
+    Reference for `validation.yaml` and `endpoints.yaml`.
+    [Read more](/05-configuration/)
+  </Card>
+  <Card title="Validation Report" icon="document">
+    Auto-generated report of all fixes applied in the latest pipeline run.
+    [Read more](/01-validation-report/)
+  </Card>
+  <Card title="Contributing" icon="github">
+    Development setup, local pipeline, tests, and PR workflow.
+    [Read more](/06-contributing/)
+  </Card>
+</CardGrid>


### PR DESCRIPTION
## Summary

- Add 5 new documentation pages covering the full pipeline lifecycle, all fix methods, Spectral rule architecture, configuration reference, and contributing guide
- Update the splash page with CardGrid navigation linking to all new sections
- 839 lines of new documentation with DRY cross-page linking throughout

Closes #113

## Test plan

- [ ] CI checks pass
- [ ] All 6 docs pages render correctly in Starlight
- [ ] Cross-page links resolve without 404s
- [ ] Code examples in docs match current pipeline implementation