### PR TITLE
fix: remove private tenant and namespace PII from codebase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,10 +1,12 @@
 # API Specs -- Repo-Specific Instructions
 
 ## Project Overview
+
 Python-based OpenAPI spec validation and reconciliation framework for F5 Distributed Cloud.
 Downloads official specs, validates them against the live API, reconciles discrepancies, and releases corrected specs.
 
 ## Key Commands
+
 - `make install` -- production setup
 - `make dev-install` -- dev setup with testing tools
 - `make validate` -- run full spec validation
@@ -15,6 +17,7 @@ Downloads official specs, validates them against the live API, reconciles discre
 - `make all` -- full pipeline: download -> validate -> reconcile -> release
 
 ## Directory Structure
+
 - `scripts/` -- Python pipeline scripts (download, validate, reconcile, release)
 - `scripts/utils/` -- Shared utilities (auth, constraint_validator, report_generator, etc.)
 - `config/` -- Pipeline configuration (endpoints.yaml, validation.yaml)
@@ -23,11 +26,13 @@ Downloads official specs, validates them against the live API, reconciles discre
 - `docs/` -- MDX documentation (Starlight format)
 
 ## Environment Variables
-```
-F5XC_API_URL=https://f5-amer-ent.console.ves.volterra.io
+
+```text
+F5XC_API_URL=https://example-tenant.console.ves.volterra.io
 F5XC_API_TOKEN=<your-api-token>
 ```
 
 ## CI Pipeline
+
 - `validate-and-release.yml` -- daily spec validation and release (6 AM UTC)
 - Governance workflows managed by docs-control

--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -3,9 +3,9 @@
 
 # API Configuration
 api:
-  base_url: "https://f5-amer-ent.console.ves.volterra.io"
-  tenant: "f5-amer-ent"
-  namespace: "r-mordasiewicz"
+  base_url: "https://example-tenant.console.ves.volterra.io"
+  tenant: "example-tenant"
+  namespace: "example-namespace"
   timeout: 30
   retries: 3
   retry_delay: 2
@@ -133,7 +133,7 @@ spectral:
       description: "F5 Distributed Cloud API"
       variables:
         tenant:
-          default: "f5-amer-ent"
+          default: "example-tenant"
           description: "Your F5 XC tenant name"
   security_scheme:
     type: "apiKey"

--- a/docs/03-fixes-applied.mdx
+++ b/docs/03-fixes-applied.mdx
@@ -51,7 +51,7 @@ Adds the F5 XC tenant URL template to specs missing a `servers` block:
   "description": "F5 Distributed Cloud API",
   "variables": {
     "tenant": {
-      "default": "f5-amer-ent",
+      "default": "example-tenant",
       "description": "Your F5 XC tenant name"
     }
   }

--- a/docs/05-configuration.mdx
+++ b/docs/05-configuration.mdx
@@ -11,9 +11,9 @@ All pipeline behavior is controlled by two YAML files in `config/`.
 
 ```yaml
 api:
-  base_url: "https://f5-amer-ent.console.ves.volterra.io"
-  tenant: "f5-amer-ent"
-  namespace: "r-mordasiewicz"
+  base_url: "https://example-tenant.console.ves.volterra.io"
+  tenant: "example-tenant"
+  namespace: "example-namespace"
   timeout: 30
   retries: 3
   retry_delay: 2
@@ -27,6 +27,19 @@ api:
 | `timeout` | HTTP request timeout in seconds. |
 | `retries` | Number of retry attempts on failure. |
 | `retry_delay` | Seconds between retries. |
+
+:::caution
+The `base_url`, `tenant`, and `namespace` values in `validation.yaml` are generic placeholders. You **must** configure these for your environment via environment variables before running the pipeline:
+
+```bash
+export F5XC_API_URL="https://example-tenant.console.ves.volterra.io"
+export F5XC_TENANT="example-tenant"
+export F5XC_NAMESPACE="example-namespace"
+export F5XC_API_TOKEN="your-api-token"
+```
+
+Environment variables take precedence over the YAML defaults at runtime.
+:::
 
 ### Download Settings
 
@@ -139,7 +152,7 @@ spectral:
       description: "F5 Distributed Cloud API"
       variables:
         tenant:
-          default: "f5-amer-ent"
+          default: "example-tenant"
           description: "Your F5 XC tenant name"
   security_scheme:
     type: "apiKey"

--- a/docs/06-contributing.mdx
+++ b/docs/06-contributing.mdx
@@ -22,7 +22,7 @@ npm install -g @stoplight/spectral-cli
 Live API validation requires:
 
 ```bash
-export F5XC_API_URL="https://f5-amer-ent.console.ves.volterra.io"
+export F5XC_API_URL="https://example-tenant.console.ves.volterra.io"
 export F5XC_API_TOKEN="your-api-token"
 ```
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -230,7 +230,7 @@ class ReleaseBuilder:
                     "url": "https://{tenant}.console.ves.volterra.io",
                     "variables": {
                         "tenant": {
-                            "default": "your-tenant",
+                            "default": "example-tenant",
                             "description": "F5 XC tenant name",
                         }
                     },

--- a/scripts/utils/auth.py
+++ b/scripts/utils/auth.py
@@ -150,14 +150,16 @@ class F5XCAuth:
 
     api_url: str = field(
         default_factory=lambda: os.getenv(
-            "F5XC_API_URL", "https://f5-amer-ent.console.ves.volterra.io"
+            "F5XC_API_URL", "https://example-tenant.console.ves.volterra.io"
         )
     )
     api_token: str = field(default_factory=lambda: os.getenv("F5XC_API_TOKEN", ""))
     namespace: str = field(
-        default_factory=lambda: os.getenv("F5XC_NAMESPACE", "r-mordasiewicz")
+        default_factory=lambda: os.getenv("F5XC_NAMESPACE", "example-namespace")
     )
-    tenant: str = field(default_factory=lambda: os.getenv("F5XC_TENANT", "f5-amer-ent"))
+    tenant: str = field(
+        default_factory=lambda: os.getenv("F5XC_TENANT", "example-tenant")
+    )
     timeout: int = 30
     retries: int = 3
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `f5-amer-ent` tenant name and `r-mordasiewicz` namespace with `example-tenant`/`example-namespace` placeholders across config, scripts, and documentation
- Actual values continue to be provided via `F5XC_API_URL` and `F5XC_API_TOKEN` environment variables at runtime
- Add env var caution callout to configuration docs

Closes #115

## Test plan

- [ ] CI checks pass
- [ ] Verify `make validate` still works with env vars set
- [ ] Verify docs render correctly with placeholder values