### PR TITLE
docs: add llms-config.json for llms.txt hierarchy

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,11 @@
+{
+  "customSets": [
+    {
+      "label": "Pipeline",
+      "description": "OpenAPI spec validation pipeline, repair rules, and configuration",
+      "paths": ["02-pipeline*", "03-fixes-applied*", "04-spectral-rules*", "05-configuration*"]
+    }
+  ],
+  "promote": ["index*", "01-validation-report*"],
+  "demote": ["06-contributing*"]
+}


### PR DESCRIPTION
## Summary

- Adds `docs/llms-config.json` with custom sets, promote, and demote lists for the starlight-llms-txt plugin
- Defines a **Pipeline** content set grouping pipeline, fixes-applied, spectral-rules, and configuration docs
- Promotes index and validation-report pages; demotes contributing page

Refs f5xc-salesdemos/xcsh#223

Step 5 of the cascading llms.txt knowledge hierarchy — adds `llms-config.json` with custom sets, promote, and demote lists so the starlight-llms-txt plugin generates tiered content output.

Closes #186

## Test plan

- [ ] CI checks pass
- [ ] Verify llms-config.json is valid JSON and matches expected schema
- [ ] Confirm starlight-llms-txt plugin picks up the config on next docs build