### PR TITLE
fix: rename routeRouteType to operateRouteRouteType in operate.route spec

### DIFF
--- a/release/specs/docs-cloud-f5-com.0198.public.ves.io.schema.operate.route.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0198.public.ves.io.schema.operate.route.ves-swagger.json
@@ -616,7 +616,7 @@
           }
         }
       },
-      "routeRouteType": {
+      "operateRouteRouteType": {
         "type": "string",
         "description": "Type of route based on where it has been learnt from\n\n - REMOTE_SITE_ROUTE: REMOTE_SITE_ROUTE\n\nRoute has been learnt from a remote site\n - LOCAL_ROUTE: LOCAL_ROUTE\n\nRoute has been generated locally\n - STATIC_ROUTE: STATIC_ROUTE\n\nRoute is a static route\n - BGP_ROUTE: BGP_ROUTE\n\nRoute has been learnt through BGP",
         "title": "Route Type",
@@ -738,7 +738,7 @@
             "x-ves-example": "192.168.10.0/24"
           },
           "route_type": {
-            "$ref": "#/components/schemas/routeRouteType"
+            "$ref": "#/components/schemas/operateRouteRouteType"
           }
         }
       },


### PR DESCRIPTION
## Summary

- Renames the `routeRouteType` schema to `operateRouteRouteType` in the `ves.io.schema.operate.route` spec to resolve a name collision with the identically-named schema in `ves.io.schema.route`
- Updates the internal `$ref` pointer so the `route_type` field references the renamed schema
- Fixes 3 contract-diff violations in the downstream api-specs-enriched pipeline caused by the collision

Closes #292

## Test plan

- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] Downstream api-specs-enriched pipeline no longer reports contract-diff violations for `routeRouteType`