### PR TITLE
feat(reconcile): config-driven schema rename engine for name collision resolution

### DIFF
--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -91,6 +91,11 @@ reconciliation:
     looser_spec: "tighten"     # Spec looser than API → tighten constraint
     missing_constraint: "add"   # Spec missing constraint → add it
     extra_constraint: "remove"  # Spec has constraint API ignores → remove it
+  schema_renames:
+    - old_name: routeRouteType
+      new_name: operateRouteRouteType
+      file_pattern: "operate.route"
+      reason: "ves.io.schema.operate.route.RouteType collides with ves.io.schema.route.RouteType"
 
 # Report Generation
 reports:

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -251,14 +251,16 @@ class SpecReconciler:
             new_ref = f"#/components/schemas/{new_name}"
             ref_count = _rewrite_refs(spec, old_ref, new_ref)
 
-            changes.append({
-                "action": "rename_schema",
-                "constraint_type": "schema-rename",
-                "old_name": old_name,
-                "new_name": new_name,
-                "references_updated": ref_count,
-                "reason": rule.get("reason", ""),
-            })
+            changes.append(
+                {
+                    "action": "rename_schema",
+                    "constraint_type": "schema-rename",
+                    "old_name": old_name,
+                    "new_name": new_name,
+                    "references_updated": ref_count,
+                    "reason": rule.get("reason", ""),
+                }
+            )
             console.print(
                 f"  [cyan]Renamed schema {old_name} → {new_name} ({ref_count} refs)[/cyan]"
             )

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -27,6 +27,21 @@ _MIN_PATH_PARTS = 3
 _TAG_SEGMENT_INDEX = 1
 
 
+def _rewrite_refs(obj: Any, old_ref: str, new_ref: str) -> int:
+    """Recursively rewrite all ``$ref`` values matching *old_ref*. Returns count."""
+    count = 0
+    if isinstance(obj, dict):
+        if obj.get("$ref") == old_ref:
+            obj["$ref"] = new_ref
+            count += 1
+        for value in obj.values():
+            count += _rewrite_refs(value, old_ref, new_ref)
+    elif isinstance(obj, list):
+        for item in obj:
+            count += _rewrite_refs(item, old_ref, new_ref)
+    return count
+
+
 @dataclass
 class ReconciliationResult:
     """Result of reconciling a single spec file."""
@@ -54,6 +69,7 @@ class ReconciliationConfig:
             "extra_constraint": "remove",
         }
     )
+    schema_renames: list[dict[str, str]] = field(default_factory=list)
 
 
 class SpecReconciler:
@@ -145,17 +161,22 @@ class SpecReconciler:
             result.validation_errors.append(str(e))
             return result
 
-        # If no discrepancies, pass through original
-        if not discrepancies:
+        # Apply fixes
+        fixed = copy.deepcopy(original)
+
+        # Apply schema renames (proactive, config-driven — runs regardless of discrepancies)
+        rename_changes = self._apply_schema_renames(fixed, spec_path.name)
+        if rename_changes:
+            result.changes.extend(rename_changes)
+            result.modified = True
+
+        if not discrepancies and not rename_changes:
             result.modified = False
             result.fixed_spec = original
             console.print(
                 f"[green]{spec_path.name}: No changes needed (pass-through)[/green]"
             )
             return result
-
-        # Apply fixes
-        fixed = copy.deepcopy(original)
 
         for discrepancy in discrepancies:
             change = self._apply_fix(fixed, discrepancy)
@@ -201,6 +222,48 @@ class SpecReconciler:
             result.fixed_spec = original
 
         return result
+
+    def _apply_schema_renames(
+        self,
+        spec: dict,
+        filename: str,
+    ) -> list[dict]:
+        """Apply config-driven schema renames and rewrite all ``$ref`` references."""
+        renames = self.config.schema_renames
+        if not renames:
+            return []
+
+        schemas = spec.get("components", {}).get("schemas", {})
+        changes: list[dict] = []
+
+        for rule in renames:
+            old_name = rule["old_name"]
+            new_name = rule["new_name"]
+            pattern = rule.get("file_pattern", "")
+
+            if pattern and pattern not in filename:
+                continue
+            if old_name not in schemas:
+                continue
+
+            schemas[new_name] = schemas.pop(old_name)
+            old_ref = f"#/components/schemas/{old_name}"
+            new_ref = f"#/components/schemas/{new_name}"
+            ref_count = _rewrite_refs(spec, old_ref, new_ref)
+
+            changes.append({
+                "action": "rename_schema",
+                "constraint_type": "schema-rename",
+                "old_name": old_name,
+                "new_name": new_name,
+                "references_updated": ref_count,
+                "reason": rule.get("reason", ""),
+            })
+            console.print(
+                f"  [cyan]Renamed schema {old_name} → {new_name} ({ref_count} refs)[/cyan]"
+            )
+
+        return changes
 
     def _apply_fix(
         self,
@@ -805,6 +868,7 @@ def main() -> int:
             "priority", ["existing", "discovery", "inferred"]
         ),
         fix_strategies=reconciliation_config.get("fix_strategies", {}),
+        schema_renames=reconciliation_config.get("schema_renames", []),
     )
 
     reconciler = SpecReconciler(

--- a/tests/test_spectral_reconcile.py
+++ b/tests/test_spectral_reconcile.py
@@ -298,73 +298,88 @@ class TestAddSecuritySchemes:
 class TestSchemaRename:
     """Tests for config-driven schema rename functionality."""
 
-    def test_rename_applied_to_matching_file(self):
-        config = ReconciliationConfig(
-            schema_renames=[{
-                "old_name": "routeRouteType",
-                "new_name": "operateRouteRouteType",
-                "file_pattern": "operate.route",
-            }],
-        )
-        reconciler = SpecReconciler(
-            original_dir=".",
-            output_dir=".",
+    @staticmethod
+    def _make_reconciler(renames):
+        from pathlib import Path
+
+        config = ReconciliationConfig(schema_renames=renames)
+        return SpecReconciler(
+            original_dir=Path("."),
+            output_dir=Path("."),
             config=config,
         )
-        spec = {
-            "components": {"schemas": {
-                "routeRouteType": {"type": "string", "enum": ["A"]},
-                "other": {"properties": {"rt": {"$ref": "#/components/schemas/routeRouteType"}}},
-            }},
+
+    def test_rename_applied_to_matching_file(self):
+        reconciler = self._make_reconciler(
+            [
+                {
+                    "old_name": "routeRouteType",
+                    "new_name": "operateRouteRouteType",
+                    "file_pattern": "operate.route",
+                },
+            ]
+        )
+        spec: dict = {
+            "components": {
+                "schemas": {
+                    "routeRouteType": {"type": "string", "enum": ["A"]},
+                    "other": {
+                        "properties": {
+                            "rt": {"$ref": "#/components/schemas/routeRouteType"},
+                        },
+                    },
+                },
+            },
         }
         changes = reconciler._apply_schema_renames(spec, "foo.operate.route.json")
         assert len(changes) == 1
         assert "operateRouteRouteType" in spec["components"]["schemas"]
         assert "routeRouteType" not in spec["components"]["schemas"]
-        assert spec["components"]["schemas"]["other"]["properties"]["rt"]["$ref"] == "#/components/schemas/operateRouteRouteType"
+        other = spec["components"]["schemas"]["other"]
+        assert isinstance(other, dict)
+        props = other["properties"]
+        assert isinstance(props, dict)
+        assert props["rt"]["$ref"] == "#/components/schemas/operateRouteRouteType"
 
     def test_rename_skipped_for_non_matching_file(self):
-        config = ReconciliationConfig(
-            schema_renames=[{
-                "old_name": "routeRouteType",
-                "new_name": "operateRouteRouteType",
-                "file_pattern": "operate.route",
-            }],
+        reconciler = self._make_reconciler(
+            [
+                {
+                    "old_name": "routeRouteType",
+                    "new_name": "operateRouteRouteType",
+                    "file_pattern": "operate.route",
+                },
+            ]
         )
-        reconciler = SpecReconciler(
-            original_dir=".",
-            output_dir=".",
-            config=config,
-        )
-        spec = {
-            "components": {"schemas": {
-                "routeRouteType": {"type": "object", "properties": {}},
-            }},
+        spec: dict = {
+            "components": {
+                "schemas": {
+                    "routeRouteType": {"type": "object", "properties": {}},
+                },
+            },
         }
         changes = reconciler._apply_schema_renames(spec, "foo.schema.route.json")
         assert len(changes) == 0
         assert "routeRouteType" in spec["components"]["schemas"]
 
     def test_rename_skipped_when_schema_absent(self):
-        config = ReconciliationConfig(
-            schema_renames=[{
-                "old_name": "routeRouteType",
-                "new_name": "operateRouteRouteType",
-                "file_pattern": "operate.route",
-            }],
+        reconciler = self._make_reconciler(
+            [
+                {
+                    "old_name": "routeRouteType",
+                    "new_name": "operateRouteRouteType",
+                    "file_pattern": "operate.route",
+                },
+            ]
         )
-        reconciler = SpecReconciler(
-            original_dir=".",
-            output_dir=".",
-            config=config,
-        )
-        spec = {"components": {"schemas": {"other": {"type": "object"}}}}
+        spec: dict = {"components": {"schemas": {"other": {"type": "object"}}}}
         changes = reconciler._apply_schema_renames(spec, "foo.operate.route.json")
         assert len(changes) == 0
 
     def test_no_renames_when_config_empty(self):
-        config = ReconciliationConfig(schema_renames=[])
-        reconciler = SpecReconciler(original_dir=".", output_dir=".", config=config)
-        spec = {"components": {"schemas": {"routeRouteType": {"type": "string"}}}}
+        reconciler = self._make_reconciler([])
+        spec: dict = {
+            "components": {"schemas": {"routeRouteType": {"type": "string"}}},
+        }
         changes = reconciler._apply_schema_renames(spec, "anything.json")
         assert len(changes) == 0

--- a/tests/test_spectral_reconcile.py
+++ b/tests/test_spectral_reconcile.py
@@ -293,3 +293,78 @@ class TestAddSecuritySchemes:
         scheme = result["components"]["securitySchemes"]["apiKeyAuth"]
         assert scheme["type"] == "apiKey"
         assert scheme["name"] == "Authorization"
+
+
+class TestSchemaRename:
+    """Tests for config-driven schema rename functionality."""
+
+    def test_rename_applied_to_matching_file(self):
+        config = ReconciliationConfig(
+            schema_renames=[{
+                "old_name": "routeRouteType",
+                "new_name": "operateRouteRouteType",
+                "file_pattern": "operate.route",
+            }],
+        )
+        reconciler = SpecReconciler(
+            original_dir=".",
+            output_dir=".",
+            config=config,
+        )
+        spec = {
+            "components": {"schemas": {
+                "routeRouteType": {"type": "string", "enum": ["A"]},
+                "other": {"properties": {"rt": {"$ref": "#/components/schemas/routeRouteType"}}},
+            }},
+        }
+        changes = reconciler._apply_schema_renames(spec, "foo.operate.route.json")
+        assert len(changes) == 1
+        assert "operateRouteRouteType" in spec["components"]["schemas"]
+        assert "routeRouteType" not in spec["components"]["schemas"]
+        assert spec["components"]["schemas"]["other"]["properties"]["rt"]["$ref"] == "#/components/schemas/operateRouteRouteType"
+
+    def test_rename_skipped_for_non_matching_file(self):
+        config = ReconciliationConfig(
+            schema_renames=[{
+                "old_name": "routeRouteType",
+                "new_name": "operateRouteRouteType",
+                "file_pattern": "operate.route",
+            }],
+        )
+        reconciler = SpecReconciler(
+            original_dir=".",
+            output_dir=".",
+            config=config,
+        )
+        spec = {
+            "components": {"schemas": {
+                "routeRouteType": {"type": "object", "properties": {}},
+            }},
+        }
+        changes = reconciler._apply_schema_renames(spec, "foo.schema.route.json")
+        assert len(changes) == 0
+        assert "routeRouteType" in spec["components"]["schemas"]
+
+    def test_rename_skipped_when_schema_absent(self):
+        config = ReconciliationConfig(
+            schema_renames=[{
+                "old_name": "routeRouteType",
+                "new_name": "operateRouteRouteType",
+                "file_pattern": "operate.route",
+            }],
+        )
+        reconciler = SpecReconciler(
+            original_dir=".",
+            output_dir=".",
+            config=config,
+        )
+        spec = {"components": {"schemas": {"other": {"type": "object"}}}}
+        changes = reconciler._apply_schema_renames(spec, "foo.operate.route.json")
+        assert len(changes) == 0
+
+    def test_no_renames_when_config_empty(self):
+        config = ReconciliationConfig(schema_renames=[])
+        reconciler = SpecReconciler(original_dir=".", output_dir=".", config=config)
+        spec = {"components": {"schemas": {"routeRouteType": {"type": "string"}}}}
+        changes = reconciler._apply_schema_renames(spec, "anything.json")
+        assert len(changes) == 0

--- a/tests/test_spectral_reconcile.py
+++ b/tests/test_spectral_reconcile.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scripts.reconcile import ReconciliationConfig, SpecReconciler
@@ -300,12 +302,10 @@ class TestSchemaRename:
 
     @staticmethod
     def _make_reconciler(renames):
-        from pathlib import Path
-
         config = ReconciliationConfig(schema_renames=renames)
         return SpecReconciler(
-            original_dir=Path("."),
-            output_dir=Path("."),
+            original_dir=Path(),
+            output_dir=Path(),
             config=config,
         )
 


### PR DESCRIPTION
## Summary

- Adds config-driven schema rename engine to the reconciliation pipeline that automatically resolves OpenAPI schema name collisions from upstream F5 source specs
- Implements `_rewrite_refs()` for recursive `$ref` rewriting and `_apply_schema_renames()` for file-pattern-matched rename rules, integrated into `_reconcile_file()` before discrepancy fixes
- First rename rule: `routeRouteType` to `operateRouteRouteType` in operate.route files (supersedes the manual fix in #293)

Closes #295

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] 4 new unit tests verify: recursive ref rewriting, schema rename application, file-pattern filtering, and no-op when patterns do not match
- [ ] Existing reconcile tests still pass (no regressions)