### PR TITLE
feat(reconcile): OAS3 deprecated markers and config-driven path removal

### DIFF
--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -96,6 +96,10 @@ reconciliation:
       new_name: operateRouteRouteType
       file_pattern: "operate.route"
       reason: "ves.io.schema.operate.route.RouteType collides with ves.io.schema.route.RouteType"
+  deprecated_path_removals:
+    - path: "/api/config/namespaces/{namespace}/api_definitions/{name}/http_loadbalancers"
+      replacement: "/api/config/namespaces/{namespace}/api_definitions/{name}/loadbalancers"
+      reason: "DEPRECATED in source description — use GetReferencingLoadBalancers"
 
 # Report Generation
 reports:

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -70,6 +70,7 @@ class ReconciliationConfig:
         }
     )
     schema_renames: list[dict[str, str]] = field(default_factory=list)
+    deprecated_path_removals: list[dict[str, str]] = field(default_factory=list)
 
 
 class SpecReconciler:
@@ -164,13 +165,15 @@ class SpecReconciler:
         # Apply fixes
         fixed = copy.deepcopy(original)
 
-        # Apply schema renames (proactive, config-driven — runs regardless of discrepancies)
+        # Proactive transforms (config-driven, run regardless of discrepancies)
         rename_changes = self._apply_schema_renames(fixed, spec_path.name)
-        if rename_changes:
-            result.changes.extend(rename_changes)
+        deprecated_changes = self._enforce_deprecated_markers(fixed)
+        proactive_changes = rename_changes + deprecated_changes
+        if proactive_changes:
+            result.changes.extend(proactive_changes)
             result.modified = True
 
-        if not discrepancies and not rename_changes:
+        if not discrepancies and not proactive_changes:
             result.modified = False
             result.fixed_spec = original
             console.print(
@@ -264,6 +267,60 @@ class SpecReconciler:
             console.print(
                 f"  [cyan]Renamed schema {old_name} → {new_name} ({ref_count} refs)[/cyan]"
             )
+
+        return changes
+
+    def _enforce_deprecated_markers(self, spec: dict) -> list[dict]:
+        """Mark operations with 'DEPRECATED' in description as ``deprecated: true``.
+
+        Also removes paths listed in ``config.deprecated_path_removals`` that
+        have known replacements.
+        """
+        changes: list[dict] = []
+        http_methods = {
+            "get",
+            "post",
+            "put",
+            "delete",
+            "patch",
+            "options",
+            "head",
+            "trace",
+        }
+
+        for path, path_item in list(spec.get("paths", {}).items()):
+            if not isinstance(path_item, dict):
+                continue
+            for method in http_methods:
+                op = path_item.get(method)
+                if not isinstance(op, dict):
+                    continue
+                desc = op.get("description", "")
+                if "DEPRECATED" in desc.upper() and not op.get("deprecated"):
+                    op["deprecated"] = True
+                    changes.append(
+                        {
+                            "action": "mark_deprecated",
+                            "constraint_type": "oas3-deprecated-marker",
+                            "path": path,
+                            "method": method,
+                        }
+                    )
+
+        for rule in self.config.deprecated_path_removals:
+            target = rule["path"]
+            if target in spec.get("paths", {}):
+                del spec["paths"][target]
+                changes.append(
+                    {
+                        "action": "remove_deprecated_path",
+                        "constraint_type": "deprecated-path-removal",
+                        "path": target,
+                        "replacement": rule.get("replacement", ""),
+                        "reason": rule.get("reason", ""),
+                    }
+                )
+                console.print(f"  [cyan]Removed deprecated path {target}[/cyan]")
 
         return changes
 
@@ -871,6 +928,9 @@ def main() -> int:
         ),
         fix_strategies=reconciliation_config.get("fix_strategies", {}),
         schema_renames=reconciliation_config.get("schema_renames", []),
+        deprecated_path_removals=reconciliation_config.get(
+            "deprecated_path_removals", []
+        ),
     )
 
     reconciler = SpecReconciler(

--- a/tests/test_spectral_reconcile.py
+++ b/tests/test_spectral_reconcile.py
@@ -383,3 +383,84 @@ class TestSchemaRename:
         }
         changes = reconciler._apply_schema_renames(spec, "anything.json")
         assert len(changes) == 0
+
+
+class TestDeprecatedMarkers:
+    """Tests for OAS3 deprecated marker enforcement and path removal."""
+
+    def test_marks_deprecated_from_description(self):
+        config = ReconciliationConfig()
+        reconciler = SpecReconciler(
+            original_dir=Path(),
+            output_dir=Path(),
+            config=config,
+        )
+        spec: dict = {
+            "paths": {
+                "/api/old": {
+                    "get": {
+                        "description": "DEPRECATED. Use /api/new instead.",
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                },
+                "/api/current": {
+                    "get": {
+                        "description": "Active endpoint.",
+                        "responses": {"200": {"description": "OK"}},
+                    },
+                },
+            },
+        }
+        changes = reconciler._enforce_deprecated_markers(spec)
+        assert len(changes) == 1
+        assert spec["paths"]["/api/old"]["get"]["deprecated"] is True
+        assert "deprecated" not in spec["paths"]["/api/current"]["get"]
+
+    def test_removes_deprecated_path_from_config(self):
+        config = ReconciliationConfig(
+            deprecated_path_removals=[
+                {
+                    "path": "/api/old",
+                    "replacement": "/api/new",
+                    "reason": "Superseded",
+                },
+            ],
+        )
+        reconciler = SpecReconciler(
+            original_dir=Path(),
+            output_dir=Path(),
+            config=config,
+        )
+        spec: dict = {
+            "paths": {
+                "/api/old": {"get": {"description": "Old"}},
+                "/api/new": {"get": {"description": "New"}},
+            },
+        }
+        changes = reconciler._enforce_deprecated_markers(spec)
+        removal_changes = [
+            c for c in changes if c["action"] == "remove_deprecated_path"
+        ]
+        assert len(removal_changes) == 1
+        assert "/api/old" not in spec["paths"]
+        assert "/api/new" in spec["paths"]
+
+    def test_skips_already_deprecated(self):
+        config = ReconciliationConfig()
+        reconciler = SpecReconciler(
+            original_dir=Path(),
+            output_dir=Path(),
+            config=config,
+        )
+        spec: dict = {
+            "paths": {
+                "/api/old": {
+                    "get": {
+                        "description": "DEPRECATED.",
+                        "deprecated": True,
+                    },
+                },
+            },
+        }
+        changes = reconciler._enforce_deprecated_markers(spec)
+        assert len(changes) == 0


### PR DESCRIPTION
## Summary

- Add `_enforce_deprecated_markers()` to scan all operations and set `deprecated: true` (OAS3 standard) when description text contains "DEPRECATED"
- Add `deprecated_path_removals` config section to remove paths with known replacements, starting with the superseded `http_loadbalancers` endpoint
- Add 3 new tests covering deprecated marker enforcement, path removal, and skip-already-deprecated behavior

Closes #299

## Test plan

- [ ] CI checks pass (lint + unit tests)
- [ ] `test_marks_deprecated_from_description` passes
- [ ] `test_removes_deprecated_path_from_config` passes
- [ ] `test_skips_already_deprecated` passes
- [ ] Existing tests remain green (no regressions)