### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -11,6 +11,7 @@ skip-path:
   - docs/specifications
   - specs/discovered
   - specs/raw
+  - specs/original
   # Install-verification dockerfiles are test harnesses, not production
   # images — CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
   # are not meaningful for ephemeral CI validation containers.
@@ -30,4 +31,29 @@ framework:
 skip-check:
   - CKV_GHA_7    # GitHub Actions — allow pinning to branch refs
   - CKV2_GHA_1   # GitHub Actions — immutable actions (covered by Dependabot)
+  - CKV_GHA_1    # GitHub Actions — ACTIONS_ALLOW_UNSECURE_COMMANDS not used
+  - CKV_GHA_2    # GitHub Actions — managed workflows use controlled inputs
+  - CKV_GHA_3    # GitHub Actions — curl with secrets in managed deploy scripts
+  - CKV_GHA_4    # GitHub Actions — no netcat usage in managed workflows
+  - CKV_GHA_5    # GitHub Actions — cosign signing not required for this org
+  - CKV_GHA_6    # GitHub Actions — cosign SBOM attestation not required
   - "CKV_SECRET_4:.*specifications/api/.*\\.json$"
+  - CKV_SECRET_2    # False positive — test fixtures and example values
+  - CKV_SECRET_6    # False positive — high entropy strings in provider schemas
+  - CKV_AZURE_1    # Lab VM — SSH key auth configured via cloud-init
+  - CKV_AZURE_9    # Lab NSG — RDP not used, SSH only
+  - CKV_AZURE_10   # Lab NSG — SSH open for demo access
+  - CKV_AZURE_50   # Lab VM — extensions not required
+  - CKV_AZURE_77   # Lab NSG — UDP services open for demo traffic
+  - CKV_AZURE_92   # Lab VM — managed disks used by default
+  - CKV_AZURE_93   # Lab VM — platform-managed encryption sufficient
+  - CKV_AZURE_118  # Lab NIC — IP forwarding disabled by default
+  - CKV_AZURE_119  # Lab NIC — public IP required for demo access
+  - CKV_AZURE_149  # Lab VM — password auth disabled, SSH keys used
+  - CKV_AZURE_160  # Lab NSG — HTTP port 80 required for demo traffic
+  - CKV_AZURE_178  # Lab VM — SSH keys configured via cloud-init
+  - CKV_AZURE_179  # Lab VM — agent installed via cloud-init
+  - CKV_AZURE_182  # Lab VNET — single DNS endpoint sufficient for demos
+  - CKV_AZURE_183  # Lab VNET — Azure default DNS sufficient for demos
+  - CKV_AZURE_220  # Lab NSG — SSH open for demo access
+  - CKV2_AZURE_31  # Lab subnet — NSG associated at NIC level

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,7 +1,18 @@
 {
   "source_repo": "f5xc-salesdemos/docs-control",
   "skip_files": {
-    "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+    "xcsh": [
+      "biome.json",
+      "LICENSE",
+      "CONTRIBUTING.md",
+      "ruff.toml",
+      ".ruff.toml",
+      ".python-lint",
+      ".mypy.ini",
+      ".github/workflows/super-linter.yml"
+    ],
+    "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps,pecified,atmost,atleast

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,9 @@ indent_size = unset
 [*.py]
 indent_size = 4
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
 [Makefile]
 indent_style = tab

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,6 @@
 ---
 name: Dependabot Auto-Merge
+
 on: pull_request_target
 
 permissions:
@@ -7,22 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
+  call:
     if: github.actor == 'dependabot[bot]'
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: f5xc-salesdemos/docs-control/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - '.github/config/**'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Commit SHA of the docs-control push that triggered this run. Forwarded to sync-managed-files for Pages staleness check.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -20,10 +26,17 @@ concurrency:
 jobs:
   enforce-settings:
     uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,10 @@ tsconfig.tsbuildinfo
 .direnv/
 /result
 
-# Workspace
+# Workspace (includes git worktree dirs for AI agents and bare-repo workflows)
 .worktrees/
+worktrees/
+.wt/
 .codex/
 playground/
 
@@ -143,6 +145,20 @@ docs/api-reference/
 .version
 .etag
 .github_release
+
+# Autoresearch session artifacts
+autoresearch.sh
+autoresearch.md
+autoresearch.program.md
+autoresearch.checks.sh
+autoresearch-loop.sh
+autoresearch.ideas.md
+autoresearch-queries.txt
+autoresearch.jsonl
+.autoresearch/
+
+# Session-resume files
+handoff.md
 
 # Union from xcsh fork (promoted 2026-04-19)
 .npm/
@@ -172,4 +188,5 @@ out.jsonl
 out.html
 pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
+packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -11,6 +11,10 @@
     "**/.git/**",
     "**/vendor/**",
     "**/internal/client/**",
-    "**/templates/**"
+    "**/internal/provider/**",
+    "**/templates/**",
+    "**/docs/resources/**",
+    "**/docs/data-sources/**",
+    "**/docs/functions/**"
   ]
 }

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -2,3 +2,38 @@
 # All single-quoted $var references in this repo are intentional jq variables,
 # not missed shell expansions.
 disable=SC2016
+
+# Disable SC1091: Not following sourced file.
+# Scripts source relative-path libraries (_lib.sh, _crapi-lib.sh, etc.)
+# that shellcheck cannot resolve in CI.
+disable=SC1091
+
+# Disable SC2034: Variable appears unused.
+# Scripts set variables consumed by sourced library files or trap handlers.
+disable=SC2034
+
+# Disable SC2064: Use single quotes for trap to prevent early expansion.
+# Scripts intentionally expand variables at trap-set time.
+disable=SC2064
+
+# Disable SC2086: Double quote to prevent globbing and word splitting.
+# Pipeline scripts and attack suites intentionally rely on word splitting.
+disable=SC2086
+
+# Disable SC2030: Modification of variable is local to subshell.
+# Parallel execution uses backgrounded subshells by design.
+disable=SC2030
+
+# Disable SC2031: Variable was modified in a subshell.
+disable=SC2031
+
+# Disable SC2045: Iterating over ls output is fragile.
+# Runner scripts iterate over numbered scripts in controlled directories.
+disable=SC2045
+
+# Disable SC2012: Use find instead of ls.
+disable=SC2012
+
+# Disable SC2001: See if you can use ${variable//search/replace}.
+# Scripts use sed for complex regex patterns.
+disable=SC2001

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,13 @@ Never run `git commit`, `git push`, `gh pr create` directly.
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <desc>\n\nFiles:\n- <list>\n\nWhy: <reason>"
 )
 ```
+
+`mode="bypassPermissions"` is required — without it, plan mode can
+re-engage mid-workflow and strip the agent's Bash access, leaving
+it stuck after the first step.
 
 See `CONTRIBUTING.md` for project rules.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,
@@ -32,6 +31,12 @@
         "enabled": false
       },
       "linter": {
+        "enabled": false
+      }
+    },
+    {
+      "includes": ["docs/specifications/api/**", "docs/api-reference/**", "tools/**"],
+      "formatter": {
         "enabled": false
       }
     },

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,19 @@
+---
+# Governance-managed Trivy configuration.
+#
+# CVE suppressions live in .trivyignore (separate managed file).
+# This file configures filesystem-scan behavior — specifically,
+# directories that must never be walked.
+
+# Python tool caches create dangling symlinks during the same CI run
+# (mypy's missing_stubs/, ruff's, pytest's). Trivy's fs walker hits
+# those symlinks between mypy-populates and trivy-scans, producing a
+# FATAL "no such file or directory" and aborting the whole scan.
+# Skipping these directories is safe: they contain no production
+# artifacts — only scratch caches regenerated each run.
+#
+# See docs-control issue #377.
+skip-dirs:
+  - .mypy_cache
+  - .ruff_cache
+  - .pytest_cache

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,11 +1,8 @@
 ---
 rules:
-  # pull_request_target required for
-  # dependabot-auto-merge and require-linked-issue
-  pull-request-target:
-    disable: true
-  # We use version tags (@v6, @v8) for
-  # first-party GitHub actions, not SHAs
+  # SHA-pinning is enforced by convention and by ref-version-mismatch.
+  # This rule's heuristic flags some valid SHA pins; redundant with
+  # the stricter rule we already rely on.
   unpinned-uses:
     disable: true
   # Low-confidence finding;


### PR DESCRIPTION
Closes #346

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- CLAUDE.md
- .editorconfig
- .gitignore
- .github/workflows/dependabot-auto-merge.yml
- biome.json
- .jscpd.json
- .checkov.yaml
- zizmor.yaml
- .shellcheckrc
- .codespellrc
- trivy.yaml
- .claude/governance.json