### PR TITLE
chore: add .etag_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ docs/specifications/api/
 docs/api-reference/
 .version
 .etag
+.etag_cache
 .github_release
 
 # Autoresearch session artifacts


### PR DESCRIPTION
Adds `.etag_cache` to `.gitignore` — this is a cache artifact from the API spec pipeline that should not be tracked.