### PR TITLE
fix: restamp stale translation sourceHash (unblocks Translation freshness)

### DIFF
--- a/docs/ar/01-validation-report.mdx
+++ b/docs/ar/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: تقرير التحقق
 description: تقرير التحقق من مواصفات F5 XC API وإصلاحها
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/ar/06-contributing.mdx
+++ b/docs/ar/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: دليل التطوير
 description: كيفية إعداد وتشغيل واختبار والمساهمة في مشروع F5 XC API Specs
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/de/01-validation-report.mdx
+++ b/docs/de/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: Validierungsbericht
 description: F5 XC API-Spezifikationsvalidierung und Korrekturbericht
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/de/06-contributing.mdx
+++ b/docs/de/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: Entwicklungsleitfaden
 description: 'Einrichtung, Ausführung, Tests und Mitwirkung am F5 XC API Specs Projekt'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/es/01-validation-report.mdx
+++ b/docs/es/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: Informe de Validación
 description: Informe de validación y corrección de especificaciones de API de F5 XC
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/es/06-contributing.mdx
+++ b/docs/es/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: Guía de Desarrollo
 description: 'Cómo configurar, ejecutar, probar y contribuir al proyecto F5 XC API Specs'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/fr/01-validation-report.mdx
+++ b/docs/fr/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: Rapport de validation
 description: Rapport de validation et de correction des spécifications API F5 XC
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/fr/06-contributing.mdx
+++ b/docs/fr/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: Guide de développement
 description: 'Comment configurer, exécuter, tester et contribuer au projet F5 XC API Specs'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/hi/01-validation-report.mdx
+++ b/docs/hi/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: सत्यापन रिपोर्ट
 description: F5 XC API स्पेक सत्यापन और सुधार रिपोर्ट
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/hi/06-contributing.mdx
+++ b/docs/hi/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: विकास मार्गदर्शिका
 description: 'F5 XC API Specs प्रोजेक्ट को सेटअप, चलाने, परीक्षण और योगदान करने का तरीका'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/it/01-validation-report.mdx
+++ b/docs/it/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: Rapporto di Validazione
 description: Rapporto di validazione e correzione delle specifiche API di F5 XC
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/it/06-contributing.mdx
+++ b/docs/it/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: Guida allo Sviluppo
 description: 'Come configurare, eseguire, testare e contribuire al progetto F5 XC API Specs'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/ja/01-validation-report.mdx
+++ b/docs/ja/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: 検証レポート
 description: F5 XC API仕様の検証および修正レポート
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/ja/06-contributing.mdx
+++ b/docs/ja/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: 開発ガイド
 description: F5 XC API Specs プロジェクトのセットアップ、実行、テスト、コントリビューション方法
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/ko/01-validation-report.mdx
+++ b/docs/ko/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: 검증 보고서
 description: F5 XC API 사양 검증 및 수정 보고서
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/ko/06-contributing.mdx
+++ b/docs/ko/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: 개발 가이드
 description: 'F5 XC API Specs 프로젝트의 설정, 실행, 테스트 및 기여 방법'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/pt-br/01-validation-report.mdx
+++ b/docs/pt-br/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: Relatório de Validação
 description: Relatório de validação e correção de especificação de API do F5 XC
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/pt-br/06-contributing.mdx
+++ b/docs/pt-br/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: Guia de Desenvolvimento
 description: 'Como configurar, executar, testar e contribuir para o projeto F5 XC API Specs'
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/th/01-validation-report.mdx
+++ b/docs/th/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: รายงานการตรวจสอบความถูกต้อง
 description: รายงานการตรวจสอบและแก้ไข API spec ของ F5 XC
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/th/06-contributing.mdx
+++ b/docs/th/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: คู่มือการพัฒนา
 description: วิธีการตั้งค่า รัน ทดสอบ และมีส่วนร่วมในโปรเจกต์ F5 XC API Specs
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/zh-cn/01-validation-report.mdx
+++ b/docs/zh-cn/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: 验证报告
 description: F5 XC API 规范验证与修复报告
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/zh-cn/06-contributing.mdx
+++ b/docs/zh-cn/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: 开发指南
 description: 如何设置、运行、测试和参与 F5 XC API Specs 项目的贡献
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 

--- a/docs/zh-tw/01-validation-report.mdx
+++ b/docs/zh-tw/01-validation-report.mdx
@@ -2,7 +2,7 @@
 title: 驗證報告
 description: F5 XC API 規格驗證與修復報告
 i18n:
-  sourceHash: a04f9047bb54
+  sourceHash: d807fc7a0af4
   translator: machine
 ---
 

--- a/docs/zh-tw/06-contributing.mdx
+++ b/docs/zh-tw/06-contributing.mdx
@@ -2,7 +2,7 @@
 title: 開發指南
 description: 如何設定、執行、測試及參與貢獻 F5 XC API Specs 專案
 i18n:
-  sourceHash: 1dc0c369e7a0
+  sourceHash: 8e5dcfa20947
   translator: machine
 ---
 


### PR DESCRIPTION
## Problem

`audit / Translation freshness` fails on 24 machine-translated locale files, blocking governance sync PR #568. Root cause: the org-rename sweep (`f5xc-salesdemos` → `f5-sales-demo`) updated en+locale content but did not restamp `i18n.sourceHash`.

Verified content-current: the only en change since each stored hash is the org rename, already applied in the locale files (guard confirmed org-rename-only for every file; 0 needing re-translation).

## Fix

Restamp `i18n.sourceHash` to `sha256(en)[:12]` in the 24 affected files. One hash line per file; no prose edits.

## Acceptance criteria
- [ ] `audit / Translation freshness` passes.
- [ ] Only `sourceHash` values change.

Unblocks governance sync PR #568.

Closes #569