### PR TITLE
fix: resolve the upstream dangling $ref that blocks every release

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -23,9 +23,10 @@ on:
         type: boolean
         default: false
 
-# Read-only default; jobs that write declare their own scope. Only `notify` needs
-# issues: write (it opens a failure issue) and `release` needs contents: write
-# (it creates the tag and release).
+# Read-only default; jobs that write declare their own scope: `validate` needs
+# issues: write (it syncs discrepancy issues), `failure-tracker` needs
+# issues: write (it opens, updates and closes the pipeline-failure issue), and
+# `release` needs contents: write (it creates the tag and release).
 permissions:
   contents: read
 
@@ -210,6 +211,10 @@ jobs:
           echo "hash=${HASH}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload validation reports
+        # Always: the Spectral gate above is the step most likely to fail, and
+        # its report is the only place the offending rule and file are
+        # recorded in full.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: validation-reports
@@ -469,50 +474,112 @@ jobs:
             echo "**Content Hash**: ${CONTENT_HASH}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  notify:
-    name: Notify on Failure
+  failure-tracker:
+    name: Failure Tracker
     needs: [validate, check-release-needed, release]
-    if: failure()
+    # Runs on success too, so the tracker it opens is also the thing that
+    # closes it. `release` is skipped when there is nothing to publish, which
+    # is not a failure.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    # Opens the pipeline-failure issue.
+    # Opens, updates or closes the single pipeline-failure tracking issue.
     permissions:
       contents: read
       issues: write
 
     steps:
-      - name: Create issue on failure
+      - name: Reconcile the failure tracker with this run
         uses: actions/github-script@v8
+        env:
+          PIPELINE_FAILED: ${{ contains(needs.*.result, 'failure') }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          CHECK_RESULT: ${{ needs.check-release-needed.result }}
+          RELEASE_RESULT: ${{ needs.release.result }}
         with:
           script: |
-            const date = new Date().toISOString().split('T')[0];
-            const title = `Validation Pipeline Failed - ${date}`;
-            const body = `
-            ## Validation Pipeline Failure
+            // One tracker, not one issue per run. The previous version opened
+            // a dated issue on every failure: thirteen consecutive runs
+            // produced thirteen near-identical issues, none of which named a
+            // cause, so a two-week outage read as routine noise. A single
+            // issue that accumulates occurrences -- and closes itself when a
+            // run succeeds -- is the signal.
+            const marker = '<!-- validate-and-release-failure-tracker -->';
+            const failed = process.env.PIPELINE_FAILED === 'true';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
 
-            **Run ID**: ${{ github.run_id }}
-            **Date**: ${date}
-            **Trigger**: ${{ github.event_name }}
-
-            ### Job Results
-            - Validate: ${{ needs.validate.result }}
-            - Check Release: ${{ needs.check-release-needed.result }}
-            - Release: ${{ needs.release.result }}
-
-            ### Actions
-            1. Check the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Review validation reports in artifacts
-            3. Fix any issues and re-run the pipeline
-
-            /cc @${{ github.repository_owner }}
-            `;
-
-            await github.rest.issues.create({
+            const open = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: title,
-              body: body,
-              labels: ['automation', 'bug']
+              state: 'open',
+              labels: 'automation',
+              per_page: 100,
             });
+            const tracker = open.find((issue) => (issue.body || '').includes(marker));
+
+            if (!failed) {
+              if (tracker) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracker.number,
+                  body: `Recovered: ${runUrl}`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracker.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.notice(`Pipeline recovered; closed #${tracker.number}`);
+              }
+              return;
+            }
+
+            const occurrence = [
+              `**Run**: ${runUrl}`,
+              `**Trigger**: ${context.eventName}`,
+              `**Date**: ${new Date().toISOString().split('T')[0]}`,
+              '',
+              '| Job | Result |',
+              '| --- | --- |',
+              `| Validate | ${process.env.VALIDATE_RESULT} |`,
+              `| Check Release | ${process.env.CHECK_RESULT} |`,
+              `| Release | ${process.env.RELEASE_RESULT} |`,
+              '',
+              'The failing step names the cause in its own log; the full',
+              'Spectral gate report is in the `validation-reports` artifact.',
+            ].join('\n');
+
+            if (tracker) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracker.number,
+                body: `Still failing.\n\n${occurrence}`,
+              });
+              core.notice(`Still failing; see #${tracker.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Validate and Release is failing',
+              body: [
+                marker,
+                '## Validate and Release is failing',
+                '',
+                'No release artifact publishes while this is red, which',
+                'strands every downstream consumer. This issue collects each',
+                'further occurrence and closes itself when a run succeeds.',
+                '',
+                occurrence,
+              ].join('\n'),
+              labels: ['automation', 'bug'],
+            });
+            core.notice(`Pipeline failed; opened #${created.data.number}`);
 
   update-docs:
     name: Update Documentation

--- a/config/dangling_ref_corrections.yaml
+++ b/config/dangling_ref_corrections.yaml
@@ -1,0 +1,72 @@
+---
+# Corrections for dangling `$ref` targets in the upstream F5 XC OpenAPI specs.
+# Applied by the fix_dangling_refs transform during `make transform`.
+#
+# A dangling `$ref` points at a component schema that no spec defines. It is
+# not a cosmetic defect: Spectral reports it as an `invalid-ref` error, the
+# release gate allows zero errors, and the whole publish stops -- so a single
+# missing message upstream strands every downstream consumer.
+#
+# SCOPE -- upstream defects only.
+# Every entry here exists because F5 ships a reference without its target. A
+# correction is only ever a repair of that specific breakage; it must never
+# invent API surface. Before adding one, confirm the target is genuinely
+# absent from the whole corpus rather than renamed:
+#
+#   python - <<'PY'
+#   import glob, json, re
+#   for path in sorted(glob.glob("specs/original/*.json")):
+#       spec = json.load(open(path))
+#       schemas = spec.get("components", {}).get("schemas", {})
+#       print(*(k for k in schemas if "<fragment>" in k), sep="\n")
+#   PY
+#
+# If the target exists under a different name, the fix is a rename in
+# `reconciliation.schema_renames` (config/validation.yaml), not a stub here.
+#
+# remedy: stub
+#   Adds an untyped object schema so the reference resolves. This is the
+#   honest repair when the target is absent everywhere: the member exists on
+#   the wire, only its shape is unpublished, and an untyped object is exactly
+#   how upstream itself models the neighbouring per-cluster status maps (see
+#   `bot_detection_ruleK8sClusterRuleConfig.sync_status_per_k8s_cluster`).
+#   A stub is never applied when upstream ships a real definition, and never
+#   injected into a spec that does not reference it, so the entry becomes
+#   inert -- not wrong -- the day F5 fixes the generator.
+#
+# Guarded by tests/test_dangling_refs.py, which fails on any dangling `$ref`
+# left in the published artifact and on any entry missing its rationale.
+
+corrections:
+  - schema: threat_intelligenceK8sClusterDeliveryStatus
+    file_pattern: shape.bot_defense.threat_intelligence.bot_detection_rule
+    referenced_by:
+      - threat_intelligenceBotInfraDeploymentDetails.properties.k8s_cluster_status
+    api_status: upstream_defect
+    remedy: stub
+    issue: https://github.com/f5-sales-demo/api-specs/issues/680
+    definition:
+      type: object
+      title: K8sClusterDeliveryStatus
+      description: >-
+        Delivery status of a bot detection rule for a single Kubernetes
+        cluster. Upstream references this message but does not publish its
+        schema, so the shape of the value is unspecified.
+      x-displayname: Kubernetes Cluster Delivery Status
+      x-ves-proto-message: >-
+        ves.io.schema.shape.bot_defense.threat_intelligence.K8sClusterDeliveryStatus
+      x-f5xc-upstream-defect: >-
+        Stub for a message F5 references but never emits. See
+        https://github.com/f5-sales-demo/api-specs/issues/680
+    notes: >-
+      BotInfraDeploymentDetails declares a three-arm oneof
+      ("bot_infra_status", "k8s_cluster_status", "region_status") and F5's
+      generator emits the schemas for two of the three arms. The message
+      ves.io.schema.shape.bot_defense.threat_intelligence.K8sClusterDeliveryStatus
+      appears nowhere in the 283-file corpus under any name, so there is
+      nothing to point the reference at. Dropping the member instead would
+      delete a live oneof arm from the API surface and desynchronise it from
+      the x-ves-oneof-field-status marker that still lists it, which misleads
+      consumers more than an unspecified value does. The reference first
+      reached the gate on 2026-07-13; every daily release failed from then
+      until this correction landed.

--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -168,5 +168,6 @@ transform:
     mark_deprecated_operations: true
     fix_property_names: true
     fix_spelling: true
+    fix_dangling_refs: true
     remove_unused_schemas: true
     inject_operation_descriptions: true

--- a/release/specs/docs-cloud-f5-com.0038.public.ves.io.schema.shape.bot_defense.threat_intelligence.bot_detection_rule.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0038.public.ves.io.schema.shape.bot_defense.threat_intelligence.bot_detection_rule.ves-swagger.json
@@ -2701,6 +2701,14 @@
             "x-ves-example": "1"
           }
         }
+      },
+      "threat_intelligenceK8sClusterDeliveryStatus": {
+        "type": "object",
+        "title": "K8sClusterDeliveryStatus",
+        "description": "Delivery status of a bot detection rule for a single Kubernetes cluster. Upstream references this message but does not publish its schema, so the shape of the value is unspecified.",
+        "x-displayname": "Kubernetes Cluster Delivery Status",
+        "x-ves-proto-message": "ves.io.schema.shape.bot_defense.threat_intelligence.K8sClusterDeliveryStatus",
+        "x-f5xc-upstream-defect": "Stub for a message F5 references but never emits. See https://github.com/f5-sales-demo/api-specs/issues/680"
       }
     },
     "securitySchemes": {

--- a/scripts/spectral_lint.py
+++ b/scripts/spectral_lint.py
@@ -34,6 +34,14 @@ UNUSED_RULES = frozenset(
     }
 )
 
+# Spectral severity codes.
+ERROR_SEVERITY = 0
+WARNING_SEVERITY = 1
+
+# Cap on the violations listed when the gate fails, so a rule that fires on
+# every spec cannot bury the log.
+MAX_REPORTED_OFFENDERS = 25
+
 
 def map_violation_to_discrepancy(violation: dict[str, Any]) -> Discrepancy:
     """Convert a Spectral JSON violation to a Discrepancy object."""
@@ -133,6 +141,36 @@ class SpectralAdapter:
             f"[green]Spectral report: {output_path} ({len(discrepancies)} issues)[/green]"
         )
 
+    @staticmethod
+    def _report_offenders(
+        violations: list[dict[str, Any]],
+        severity: int,
+    ) -> None:
+        """Print the violations that breached the gate.
+
+        The counts alone say nothing actionable: a dangling ``$ref`` reported
+        as ``1 errors exceeds max 0`` went undiagnosed through thirteen
+        consecutive daily runs because the cause lived only in an uploaded
+        artifact. Printing the rule, the file, the location and the message
+        makes the log itself sufficient.
+        """
+        offenders = [v for v in violations if v.get("severity") == severity]
+        label = "error" if severity == ERROR_SEVERITY else "warning"
+        console.print(f"[red]Offending {label}s ({len(offenders)}):[/red]")
+
+        for violation in offenders[:MAX_REPORTED_OFFENDERS]:
+            source = violation.get("source", "")
+            filename = Path(source).name if source else "<unknown file>"
+            location = ".".join(str(p) for p in violation.get("path", []))
+            console.print(
+                f"  [red]{violation.get('code', '<unknown rule>')}[/red] "
+                f"{filename} {location}: {violation.get('message', '')}"
+            )
+
+        remaining = len(offenders) - MAX_REPORTED_OFFENDERS
+        if remaining > 0:
+            console.print(f"  [dim]... and {remaining} more[/dim]")
+
     def check_gate(
         self,
         violations: list[dict[str, Any]],
@@ -143,19 +181,17 @@ class SpectralAdapter:
         error_count = sum(1 for v in violations if v.get("severity") == 0)
         warn_count = sum(1 for v in violations if v.get("severity") == 1)
 
-        console.print(
-            f"[dim]Gate check: {error_count} errors, {warn_count} warnings[/dim]"
-        )
+        console.print(f"[dim]Gate check: {error_count} errors, {warn_count} warnings[/dim]")
 
         if max_errors is not None and error_count > max_errors:
-            console.print(
-                f"[red]Gate FAILED: {error_count} errors exceeds max {max_errors}[/red]"
-            )
+            console.print(f"[red]Gate FAILED: {error_count} errors exceeds max {max_errors}[/red]")
+            self._report_offenders(violations, ERROR_SEVERITY)
             return False
         if max_warnings is not None and warn_count > max_warnings:
             console.print(
                 f"[red]Gate FAILED: {warn_count} warnings exceeds max {max_warnings}[/red]"
             )
+            self._report_offenders(violations, WARNING_SEVERITY)
             return False
 
         console.print("[green]Gate PASSED[/green]")
@@ -214,9 +250,7 @@ def main() -> int:
         violations = adapter.run_lint(spec_dir)
         adapter.write_report(violations, output)
 
-        console.print(
-            f"[bold]Spectral discover: {len(violations)} violations found[/bold]"
-        )
+        console.print(f"[bold]Spectral discover: {len(violations)} violations found[/bold]")
         return 0
 
     # gate mode

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -40,6 +40,14 @@ DEFAULT_SPELLING_TEXT_FIELDS: tuple[str, ...] = (
     "x-displayname",
 )
 
+# Prefix of a local component-schema reference.
+SCHEMA_REF_PREFIX = "#/components/schemas/"
+
+# The only remedy ``fix_dangling_refs`` implements. Declared in
+# ``dangling_ref_corrections.yaml`` so a correction states its intent and an
+# unimplemented one fails loudly instead of silently doing nothing.
+STUB_REMEDY = "stub"
+
 # ---------------------------------------------------------------------------
 # Transform registry
 # ---------------------------------------------------------------------------
@@ -194,6 +202,36 @@ def _collect_refs(obj: Any) -> set[str]:
         for item in obj:
             refs.update(_collect_refs(item))
     return refs
+
+
+def find_dangling_refs(spec: dict) -> list[tuple[str, str]]:
+    """Return ``(path, schema name)`` for every local ``$ref`` with no definition.
+
+    Only ``#/components/schemas/`` references are considered: they are the only
+    ones this pipeline can resolve, and they are the ones Spectral rejects as
+    ``invalid-ref`` errors. *path* is the dotted location of the ``$ref`` key,
+    matching the ``property_name`` format the Spectral report uses, so a
+    finding can be quoted straight into a failure message.
+    """
+    schemas = (spec.get("components") or {}).get("schemas") or {}
+    dangling: list[tuple[str, str]] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                child = f"{path}.{key}" if path else key
+                if key != "$ref" or not isinstance(value, str):
+                    walk(value, child)
+                elif value.startswith(SCHEMA_REF_PREFIX):
+                    name = value[len(SCHEMA_REF_PREFIX) :]
+                    if name not in schemas:
+                        dangling.append((child, name))
+        elif isinstance(node, list):
+            for index, item in enumerate(node):
+                walk(item, f"{path}.{index}")
+
+    walk(spec, "")
+    return dangling
 
 
 # ---------------------------------------------------------------------------
@@ -417,6 +455,59 @@ def mark_deprecated_operations(
     return spec
 
 
+@register_transform("fix_dangling_refs")
+def fix_dangling_refs(
+    spec: dict,
+    config: TransformConfig,
+    filename: str,
+) -> dict:
+    """Repair ``$ref`` targets that upstream references but never defines.
+
+    A dangling reference is an ``invalid-ref`` error to Spectral, and the
+    release gate allows zero errors, so one of them stops the publish for
+    every consumer. Each repair is declared in
+    ``config/dangling_ref_corrections.yaml`` -- see that file for the rules a
+    correction must satisfy.
+
+    Runs before :func:`remove_unused_schemas` so an injected stub takes part
+    in the reachability walk like any other schema.
+    """
+    corrections = config.metadata.get("dangling_ref_corrections", [])
+    if not corrections:
+        return spec
+
+    for rule in corrections:
+        schema_name = rule.get("schema", "<unnamed>")
+        remedy = rule.get("remedy")
+        if remedy != STUB_REMEDY:
+            msg = (
+                f"{schema_name}: unsupported dangling-ref remedy {remedy!r}; "
+                f"only {STUB_REMEDY!r} is implemented"
+            )
+            raise ValueError(msg)
+        if not rule.get("definition"):
+            msg = f"{schema_name}: {STUB_REMEDY} correction without a definition"
+            raise ValueError(msg)
+
+    # Names only: a stub resolves every reference to it at once.
+    dangling = {name for _, name in find_dangling_refs(spec)}
+    if not dangling:
+        return spec
+
+    for rule in corrections:
+        schema_name = rule["schema"]
+        file_pattern = rule.get("file_pattern")
+        if file_pattern and file_pattern not in filename:
+            continue
+        if schema_name not in dangling:
+            continue
+
+        schemas = spec.setdefault("components", {}).setdefault("schemas", {})
+        schemas[schema_name] = copy.deepcopy(rule["definition"])
+
+    return spec
+
+
 @register_transform("remove_unused_schemas")
 def remove_unused_schemas(
     spec: dict,
@@ -441,7 +532,7 @@ def remove_unused_schemas(
             external_refs.update(_collect_refs(top_value))
 
     # Seed: schemas referenced externally.
-    prefix = "#/components/schemas/"
+    prefix = SCHEMA_REF_PREFIX
     reachable: set[str] = set()
     frontier = [
         ref[len(prefix) :]
@@ -667,6 +758,12 @@ def load_config(config_path: str | Path) -> TransformConfig:
         with property_path.open() as fh:
             property_cfg = yaml.safe_load(fh) or {}
         metadata["property_name_corrections"] = property_cfg.get("corrections", [])
+
+    dangling_ref_path = config_path.parent / "dangling_ref_corrections.yaml"
+    if dangling_ref_path.exists():
+        with dangling_ref_path.open() as fh:
+            dangling_ref_cfg = yaml.safe_load(fh) or {}
+        metadata["dangling_ref_corrections"] = dangling_ref_cfg.get("corrections", [])
 
     return TransformConfig(
         input_dir=str(input_dir),

--- a/tests/test_dangling_refs.py
+++ b/tests/test_dangling_refs.py
@@ -1,0 +1,243 @@
+"""Guard tests for dangling ``$ref`` targets in the published specs.
+
+A ``$ref`` that points at a schema no spec defines is fatal to every consumer:
+Spectral rejects it with ``invalid-ref``, which is an error, and the quality
+gate is configured for zero errors. One such reference in the upstream input
+therefore stops the release job, and no artifact publishes at all.
+
+Two invariants are enforced here:
+
+1. The published ``release/specs`` artifact contains no dangling ``$ref``.
+   The failure names the file, the JSON pointer and the missing schema, so a
+   regression is diagnosable from the assertion alone rather than from a
+   Spectral error count.
+2. ``fix_dangling_refs`` applies the corrections declared in
+   ``config/dangling_ref_corrections.yaml`` and only those: it never
+   overwrites a definition upstream already ships, never injects a schema
+   nothing references, and rejects an unknown remedy instead of silently
+   doing nothing.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.transform import (
+    TransformConfig,
+    find_dangling_refs,
+    fix_dangling_refs,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELEASE_SPECS_DIR = REPO_ROOT / "release" / "specs"
+DANGLING_REF_CONFIG = REPO_ROOT / "config" / "dangling_ref_corrections.yaml"
+
+# The upstream defect this guard was written for: F5 emits the
+# ``k8s_cluster_status`` member of ``BotInfraDeploymentDetails`` but never
+# emits the message it points at.
+UPSTREAM_DEFECT_SCHEMA = "threat_intelligenceK8sClusterDeliveryStatus"
+UPSTREAM_DEFECT_FILE = (
+    "docs-cloud-f5-com.0038.public.ves.io.schema.shape.bot_defense"
+    ".threat_intelligence.bot_detection_rule.ves-swagger.json"
+)
+
+# Maximum number of offending references quoted in an assertion message.
+_MAX_REPORTED = 20
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def corrections() -> list[dict[str, Any]]:
+    with DANGLING_REF_CONFIG.open() as fh:
+        raw = yaml.safe_load(fh) or {}
+    return raw.get("corrections", [])
+
+
+@pytest.fixture(scope="module")
+def config(corrections: list[dict[str, Any]]) -> TransformConfig:
+    return TransformConfig(metadata={"dangling_ref_corrections": corrections})
+
+
+@pytest.fixture
+def defective_spec() -> dict:
+    """A spec shaped like the upstream defect: a member with no definition."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Test", "version": ""},
+        "paths": {},
+        "components": {
+            "schemas": {
+                "threat_intelligenceBotInfraDeploymentDetails": {
+                    "type": "object",
+                    "x-ves-oneof-field-status": (
+                        '["bot_infra_status","k8s_cluster_status","region_status"]'
+                    ),
+                    "properties": {
+                        "k8s_cluster_status": {
+                            "$ref": f"#/components/schemas/{UPSTREAM_DEFECT_SCHEMA}"
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# find_dangling_refs
+# ---------------------------------------------------------------------------
+
+
+class TestFindDanglingRefs:
+    def test_reports_pointer_and_schema_name(self, defective_spec: dict) -> None:
+        assert find_dangling_refs(defective_spec) == [
+            (
+                "components.schemas.threat_intelligenceBotInfraDeploymentDetails"
+                ".properties.k8s_cluster_status.$ref",
+                UPSTREAM_DEFECT_SCHEMA,
+            )
+        ]
+
+    def test_resolvable_ref_is_not_reported(self, defective_spec: dict) -> None:
+        defective_spec["components"]["schemas"][UPSTREAM_DEFECT_SCHEMA] = {"type": "object"}
+        assert not find_dangling_refs(defective_spec)
+
+    def test_spec_without_components_is_clean(self) -> None:
+        assert not find_dangling_refs({"openapi": "3.0.0", "paths": {}})
+
+    def test_external_ref_is_ignored(self) -> None:
+        spec = {"components": {"schemas": {}}, "paths": {"/a": {"$ref": "other.json"}}}
+        assert not find_dangling_refs(spec)
+
+
+# ---------------------------------------------------------------------------
+# fix_dangling_refs
+# ---------------------------------------------------------------------------
+
+
+class TestFixDanglingRefs:
+    def test_upstream_defect_is_stubbed(
+        self, defective_spec: dict, config: TransformConfig
+    ) -> None:
+        fixed = fix_dangling_refs(defective_spec, config, UPSTREAM_DEFECT_FILE)
+
+        assert not find_dangling_refs(fixed)
+        stub = fixed["components"]["schemas"][UPSTREAM_DEFECT_SCHEMA]
+        assert stub["type"] == "object"
+        # A stub must not invent API surface.
+        assert "properties" not in stub
+
+    def test_existing_definition_is_never_overwritten(
+        self, defective_spec: dict, config: TransformConfig
+    ) -> None:
+        upstream = {"type": "object", "properties": {"cluster": {"type": "string"}}}
+        defective_spec["components"]["schemas"][UPSTREAM_DEFECT_SCHEMA] = copy.deepcopy(upstream)
+
+        fixed = fix_dangling_refs(defective_spec, config, UPSTREAM_DEFECT_FILE)
+
+        assert fixed["components"]["schemas"][UPSTREAM_DEFECT_SCHEMA] == upstream
+
+    def test_other_files_are_untouched(self, defective_spec: dict, config: TransformConfig) -> None:
+        fixed = fix_dangling_refs(defective_spec, config, "some.other.spec.json")
+
+        assert UPSTREAM_DEFECT_SCHEMA not in fixed["components"]["schemas"]
+
+    def test_unreferenced_schema_is_not_injected(self, config: TransformConfig) -> None:
+        spec = {"components": {"schemas": {"other": {"type": "object"}}}}
+
+        fixed = fix_dangling_refs(spec, config, UPSTREAM_DEFECT_FILE)
+
+        assert UPSTREAM_DEFECT_SCHEMA not in fixed["components"]["schemas"]
+
+    def test_unknown_remedy_is_rejected(self, defective_spec: dict) -> None:
+        config = TransformConfig(
+            metadata={
+                "dangling_ref_corrections": [
+                    {"schema": UPSTREAM_DEFECT_SCHEMA, "remedy": "wish-it-away"}
+                ]
+            }
+        )
+
+        with pytest.raises(ValueError, match="wish-it-away"):
+            fix_dangling_refs(defective_spec, config, UPSTREAM_DEFECT_FILE)
+
+    def test_stub_without_a_definition_is_rejected(self, defective_spec: dict) -> None:
+        config = TransformConfig(
+            metadata={
+                "dangling_ref_corrections": [{"schema": UPSTREAM_DEFECT_SCHEMA, "remedy": "stub"}]
+            }
+        )
+
+        with pytest.raises(ValueError, match="without a definition"):
+            fix_dangling_refs(defective_spec, config, UPSTREAM_DEFECT_FILE)
+
+    def test_no_corrections_configured_is_a_noop(self, defective_spec: dict) -> None:
+        before = copy.deepcopy(defective_spec)
+
+        fixed = fix_dangling_refs(defective_spec, TransformConfig(), UPSTREAM_DEFECT_FILE)
+
+        assert fixed == before
+
+
+# ---------------------------------------------------------------------------
+# Correction configuration
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectionConfig:
+    def test_upstream_defect_is_tracked(self, corrections: list[dict]) -> None:
+        assert [c["schema"] for c in corrections].count(UPSTREAM_DEFECT_SCHEMA) == 1
+
+    def test_every_correction_is_justified(self, corrections: list[dict]) -> None:
+        for rule in corrections:
+            schema = rule.get("schema")
+            assert schema, f"correction without a schema: {rule}"
+            assert rule.get("remedy") == "stub", f"{schema}: unsupported remedy"
+            assert rule.get("api_status") == "upstream_defect", (
+                f"{schema}: corrections must record why upstream is wrong"
+            )
+            assert rule.get("notes"), f"{schema}: missing rationale"
+            assert rule.get("referenced_by"), f"{schema}: missing referencing member"
+            definition = rule.get("definition") or {}
+            assert definition.get("type") == "object", f"{schema}: stub must be typed"
+            assert "properties" not in definition, f"{schema}: a stub must not invent API surface"
+            assert definition.get("x-ves-proto-message"), (
+                f"{schema}: stub must name the upstream proto message"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Published artifact
+# ---------------------------------------------------------------------------
+
+
+class TestPublishedSpecs:
+    def test_published_specs_have_no_dangling_refs(self) -> None:
+        spec_files = sorted(RELEASE_SPECS_DIR.glob("*.json"))
+        assert spec_files, f"No published specs found in {RELEASE_SPECS_DIR}"
+
+        offenders: list[str] = []
+        for spec_file in spec_files:
+            with spec_file.open() as fh:
+                spec = json.load(fh)
+            offenders.extend(
+                f"{spec_file.name}: {pointer} -> {schema}"
+                for pointer, schema in find_dangling_refs(spec)
+            )
+
+        assert not offenders, (
+            f"{len(offenders)} dangling $ref(s) in the published specs; "
+            "Spectral rejects each one as an invalid-ref error and the release "
+            "gate allows zero errors. Add a correction to "
+            "config/dangling_ref_corrections.yaml:\n  " + "\n  ".join(offenders[:_MAX_REPORTED])
+        )

--- a/tests/test_spectral_lint.py
+++ b/tests/test_spectral_lint.py
@@ -31,6 +31,18 @@ SAMPLE_VIOLATION_TAGS = {
     "source": "/workspace/api-specs/release/specs/test-spec.json",
 }
 
+SAMPLE_VIOLATION_INVALID_REF = {
+    "code": "invalid-ref",
+    "path": ["components", "schemas", "Details", "properties", "status", "$ref"],
+    "message": "'#/components/schemas/MissingStatus' does not exist",
+    "severity": 0,
+    "range": {
+        "start": {"line": 300, "character": 0},
+        "end": {"line": 302, "character": 0},
+    },
+    "source": "/workspace/api-specs/release/specs/test-spec.json",
+}
+
 SAMPLE_VIOLATION_UNUSED = {
     "code": "oas3-unused-component",
     "path": ["components", "schemas", "UnusedSchema"],
@@ -79,9 +91,7 @@ class TestMapViolationToDiscrepancy:
         d = map_violation_to_discrepancy(SAMPLE_VIOLATION_TAGS)
         assert d.constraint_type == "spectral:operation-tags"
         assert d.discrepancy_type == DiscrepancyType.SPECTRAL_MISSING
-        assert (
-            d.property_name == "paths./api/config/namespaces/{namespace}/resources.post"
-        )
+        assert d.property_name == "paths./api/config/namespaces/{namespace}/resources.post"
 
     def test_unused_component_maps_to_spectral_unused(self):
         d = map_violation_to_discrepancy(SAMPLE_VIOLATION_UNUSED)
@@ -100,6 +110,53 @@ class TestMapViolationToDiscrepancy:
         assert d.discrepancy_type == DiscrepancyType.SPECTRAL_INVALID
 
 
+class TestSpectralAdapterGate:
+    """The gate must name what failed.
+
+    A bare ``1 errors exceeds max 0`` kept a dangling ``$ref`` unexplained in
+    the daily log for thirteen consecutive runs; reading the cause required
+    downloading an artifact, so nobody did.
+    """
+
+    @staticmethod
+    def _capture(capsys) -> str:
+        return " ".join(capsys.readouterr().out.split())
+
+    def test_failure_names_every_offending_error(self, monkeypatch, capsys):
+        monkeypatch.setenv("COLUMNS", "300")
+        adapter = SpectralAdapter(ruleset=".spectral.yaml")
+
+        violations = [SAMPLE_VIOLATION_INVALID_REF, SAMPLE_VIOLATION_TAGS]
+        passed = adapter.check_gate(violations, 0, None)
+
+        out = self._capture(capsys)
+        assert passed is False
+        assert "invalid-ref" in out
+        assert "test-spec.json" in out
+        assert "components.schemas.Details.properties.status.$ref" in out
+        assert "does not exist" in out
+
+    def test_warnings_are_not_listed_when_the_gate_passes(self, monkeypatch, capsys):
+        monkeypatch.setenv("COLUMNS", "300")
+        adapter = SpectralAdapter(ruleset=".spectral.yaml")
+
+        passed = adapter.check_gate([SAMPLE_VIOLATION_TAGS], 0, None)
+
+        out = self._capture(capsys)
+        assert passed is True
+        assert "operation-tags" not in out
+
+    def test_warning_budget_breach_names_the_warnings(self, monkeypatch, capsys):
+        monkeypatch.setenv("COLUMNS", "300")
+        adapter = SpectralAdapter(ruleset=".spectral.yaml")
+
+        passed = adapter.check_gate([SAMPLE_VIOLATION_TAGS], None, 0)
+
+        out = self._capture(capsys)
+        assert passed is False
+        assert "operation-tags" in out
+
+
 class TestSpectralAdapterWriteReport:
     def test_write_report_creates_valid_json(self, tmp_path):
         violations = [SAMPLE_VIOLATION_SERVERS, SAMPLE_VIOLATION_TAGS]
@@ -110,6 +167,4 @@ class TestSpectralAdapterWriteReport:
         report = json.loads(report_path.read_text())
         assert "discrepancies" in report
         assert len(report["discrepancies"]) == 2
-        assert (
-            report["discrepancies"][0]["constraint_type"] == "spectral:oas3-api-servers"
-        )
+        assert report["discrepancies"][0]["constraint_type"] == "spectral:oas3-api-servers"


### PR DESCRIPTION
Closes #680

## Problem

`Validate and Release` has failed on **every run since 2026-07-13** — thirteen consecutive days — at the Spectral gate. No artifact has published since `v2026.07.12`, so `api-specs-enriched` and the Terraform provider are stranded on a two-week-old release and no correction made in this buffer zone can ship.

## Root cause

One reference in the upstream input. F5's generator emits
`threat_intelligenceBotInfraDeploymentDetails` with a three-arm oneof
(`bot_infra_status`, `k8s_cluster_status`, `region_status`) and publishes the schemas for two of them. The third points at
`ves.io.schema.shape.bot_defense.threat_intelligence.K8sClusterDeliveryStatus`, which appears **nowhere in the 283-file corpus under any name** — verified against the current upstream drop (spec date 2026.07.24). Spectral scores it `invalid-ref`, severity error, and the gate allows zero errors.

```text
Gate check: 1 errors, 516 warnings
Gate FAILED: 1 errors exceeds max 0
```

## Remedy — stub, declared as an upstream defect

The target is genuinely absent, not renamed, so there is nothing to repoint at. It is stubbed as an untyped object, which is exactly how upstream itself models the neighbouring per-cluster status map (`bot_detection_ruleK8sClusterRuleConfig.sync_status_per_k8s_cluster`): the member exists on the wire, only its shape is unpublished.

Pruning the member instead would delete a live oneof arm from the API surface and contradict the `x-ves-oneof-field-status` marker that still lists it — that misleads consumers more than an unspecified value does. No Spectral rule was relaxed, disabled or excepted.

The repair is data-driven, following `spelling_corrections.yaml` / `property_name_corrections.yaml`:

- `config/dangling_ref_corrections.yaml` — the correction with `api_status: upstream_defect`, the referencing member, and the rationale, so the defect stays visible.
- `fix_dangling_refs` in `scripts/transform.py` — applies it. Never overwrites a definition upstream ships, never injects a schema nothing references, rejects an unsupported remedy loudly. The entry goes inert the day F5 fixes its generator.

## Making the failure loud

Two defects let this run for two weeks unnoticed:

1. The gate printed `1 errors exceeds max 0` and nothing else — the cause lived only in an artifact that is not even uploaded when the gate fails. The offending rule, file, location and message now print, and `validation-reports` uploads with `if: always()`.
2. The notifier opened a **new dated issue per failure** — thirteen near-identical issues (#606, #622, #635, #648, #649, #656, #667, #674, #678 …), none naming a cause, so the outage read as routine noise. `notify` is now a single `failure-tracker` job that opens one tracking issue, comments each further occurrence on it, and closes it when a run succeeds.

## Regression test

`tests/test_dangling_refs.py` — 14 tests. `TestPublishedSpecs::test_published_specs_have_no_dangling_refs` scans every published spec and fails with the file, the location and the missing schema:

```text
AssertionError: 1 dangling $ref(s) in the published specs; Spectral rejects each one
as an invalid-ref error and the release gate allows zero errors.
  docs-cloud-f5-com.0000...json: components.schemas._guard_probe.$ref -> thisSchemaDoesNotExist
```

## Verification (local, full pipeline)

```text
$ python -m scripts.transform                 # 283 specs, 0 dangling refs remain
$ python -m scripts.spectral_lint --mode gate
Running Spectral on 523 specs...
Gate check: 0 errors, 516 warnings            # was: 1 errors -> FAILED
Gate PASSED
$ python -m scripts.release --version 2026.07.24-local
release/api-specs-v2026.07.24-local.zip       # 9.2 MB, 0 dangling refs, stub present in openapi.json
```

Gate failure output, before/after, on the unfixed spec:

```text
Gate FAILED: 1 errors exceeds max 0
Offending errors (1):
  invalid-ref docs-cloud-f5-com.0038...bot_detection_rule.ves-swagger.json
  components.schemas.threat_intelligenceBotInfraDeploymentDetails.properties.k8s_cluster_status.$ref:
  '#/components/schemas/threat_intelligenceK8sClusterDeliveryStatus' does not exist
```

`pytest`: 142 passed, 1 skipped. `ruff check`, `mypy`, `pylint` (10.00/10), `codespell`, `yamllint`, `actionlint`: clean. Remaining `pre-commit` findings are pre-existing on `main` and in files this PR does not touch (`README.md` MD012, `docs/*/spelling-audit.mdx` codespell, `.ruff.toml` EOL, zizmor `npm install -g`).

## Published artifact

Rebased onto #679 (merged), which un-ignored `release/specs` and pruned its stale files. `release/specs` is regenerated with the pipeline: the diff is a single file, `+8` lines — the stub. With the stale copies gone, the gate now runs on exactly 283 specs:

```text
Running Spectral on 283 specs...
Gate check: 0 errors, 4 warnings
Gate PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
