### PR TITLE
S9: stop exporting F5's misspelled property names — correct the presented name, preserve the wire key

### DIFF
--- a/config/property_name_corrections.yaml
+++ b/config/property_name_corrections.yaml
@@ -2,32 +2,49 @@
 # Property name corrections for misspelled JSON keys in
 # OpenAPI spec schemas.
 #
-# Property names are STRUCTURAL — changing them alters
-# the API contract. Each correction must be verified
-# against the live F5 XC API before applying.
+# The presented name and the wire key are two different
+# things. `fix_property_names` always corrects the
+# presented name; `api_status` decides what happens to
+# the wire key:
+#
+#   fix_spec  (with verified: true)
+#     The live API itself uses the corrected key. Rename
+#     outright — the wire key changes with the name.
+#
+#   upstream_typo / upstream_typo_permanent / unverifiable
+#     The API requires (or is not proven not to require)
+#     F5's misspelling. Rename the property AND emit
+#     `x-f5xc-wire-name: <old_key>` on it, so downstream
+#     consumers present the corrected name and marshal
+#     the original key. The bytes on the wire do not move.
+#
+# Fields:
+#   schema     Representative schema the typo was probed
+#              against. The rename is applied to EVERY
+#              schema declaring `old_key`, because F5
+#              repeats the same field across siblings.
+#   verified   Whether the live API was actually observed.
+#              `false` means unverifiable, never unchecked.
+#   api_status What was observed (see above).
 #
 # Workflow:
 #   1. Add suspected typos with verified: false
-#   2. Run `make verify-property-names` to probe the API
-#   3. Script marks verified: true where the API uses the
-#      corrected name (not the misspelled one)
-#   4. `make transform` applies only verified corrections
+#   2. Run `make verify-property-names` with --apply to
+#      probe the live API and record verified/api_status
+#   3. `make transform` corrects every presented name and
+#      preserves every wire key that is not `fix_spec`
 #
-# If the API returns the misspelled key, the spec is
-# correct and the fix must happen upstream.
+# The retired `never_apply: true` flag protected a wire key
+# by declining the rename outright, which left F5's typo in
+# every generated consumer. `upstream_typo_permanent` now
+# carries that knowledge instead, and the wire key is held
+# by `x-f5xc-wire-name` rather than by not renaming.
 #
-# never_apply: true marks a correction that must never be
-# applied, because the live API requires the misspelled
-# key and silently ignores the corrected one. The
-# fix_property_names transform skips such rules
-# unconditionally, and verify_property_names refuses to
-# promote them to verified: true.
-#
-# Last verified: 2026-06-09
-# Tenant: nferreira.staging.volterra.us
+# Last verified: 2026-07-25
+# Tenant: f5-amer-ent.console.ves.volterra.io
 
 corrections:
-  # --- Verified: safe to fix ---
+  # --- Verified: API uses the corrected key, safe to rename outright ---
 
   - schema: fleetFlashBladeEndpoint
     old_key: lables
@@ -37,107 +54,132 @@ corrections:
     probe_endpoint: /api/config/namespaces/system/fleets
     probe_method: GET
     notes: >-
-      API returns 'labels'.
-      Spec should be corrected. 2 files.
+      Re-probed 2026-07-25: HTTP 200, response carries
+      'labels' and never 'lables'. Spec-only typo.
+      2 occurrences.
 
-  # --- Verified: upstream platform typos ---
+  # --- Verified upstream platform typos: wire key preserved ---
 
   - schema: schemasiteGetSpecType
     old_key: volterra_software_overide
     new_key: volterra_software_override
-    verified: false
+    verified: true
     api_status: upstream_typo
     probe_endpoint: /api/config/namespaces/system/sites
     probe_method: GET
     notes: >-
-      API returns the misspelled key.
-      Typo is in the platform.
+      Re-probed 2026-07-25: HTTP 200, response carries
+      'volterra_software_overide'. Typo is in the
+      platform. Also in schemasiteReplaceSpecType.
 
-  - schema: clusterGetSpecType
+  - schema: origin_poolOriginPoolAdvancedOptions
     old_key: disable_lb_source_ip_persistance
     new_key: disable_lb_source_ip_persistence
-    verified: false
+    verified: true
     api_status: upstream_typo
-    probe_endpoint: /api/config/namespaces/system/clusters
+    probe_endpoint: /api/config/namespaces/{namespace}/origin_pools
     probe_method: GET
     notes: >-
-      API returns the misspelled key.
-      Typo is in the platform.
+      Re-probed 2026-07-25: HTTP 200 across 285 namespaces,
+      31 of them return 'disable_lb_source_ip_persistance'
+      and none the corrected spelling. Also in
+      clusterGetSpecType. Named by the sibling
+      x-ves-oneof-field-lb_source_ip_persistance_choice.
 
-  - schema: clusterGetSpecType
+  - schema: origin_poolOriginPoolAdvancedOptions
     old_key: enable_lb_source_ip_persistance
     new_key: enable_lb_source_ip_persistence
-    verified: false
+    verified: true
     api_status: upstream_typo
-    probe_endpoint: /api/config/namespaces/system/clusters
+    probe_endpoint: /api/config/namespaces/{namespace}/origin_pools
     probe_method: GET
     notes: >-
-      Paired with disable_ variant.
-      Same upstream platform typo.
+      Paired with the disable_ variant, same upstream
+      platform typo, same 2026-07-25 probe. Also in
+      clusterGetSpecType.
 
   - schema: namespaceHTTPLoadbalancerInventoryFilterType
     old_key: public_advertisment
     new_key: public_advertisement
-    verified: false
+    verified: true
     api_status: upstream_typo
-    probe_endpoint: >-
-      /api/config/namespaces/{namespace}/application_inventory
+    probe_endpoint: /api/config/namespaces/system/all_application_inventory
     probe_method: POST
     notes: >-
-      API returns 'public_advertisment' alongside correct
+      Re-probed 2026-07-25: HTTP 200, response carries
+      'public_advertisment' alongside the correctly spelled
       'private_advertisement'. Inconsistent upstream typo.
-      9 occurrences across HTTP/TCP/UDP LB types.
+      8 occurrences across HTTP/TCP/UDP LB types.
 
-  # --- NEVER APPLY: the misspelling is the wire contract ---
+  - schema: namespaceHTTPLoadbalancerResultType
+    old_key: public_advertisment_enabled
+    new_key: public_advertisement_enabled
+    verified: true
+    api_status: upstream_typo
+    probe_endpoint: /api/config/namespaces/system/all_application_inventory
+    probe_method: POST
+    notes: >-
+      Sibling of public_advertisment on the result type.
+      Re-probed 2026-07-25: HTTP 200, response carries
+      'public_advertisment_enabled' next to
+      'private_advertisement_enabled'.
+
+  # --- Permanent wire contract: the wire key can never move ---
 
   - schema: fleetBlockedServicesListType
     old_key: blocked_sevice
     new_key: blocked_service
-    verified: false
-    never_apply: true
+    verified: true
     api_status: upstream_typo_permanent
-    probe_endpoint: >-
-      /api/config/namespaces/system/azure_vnet_sites
-    probe_method: PUT
+    probe_endpoint: /api/config/namespaces/system/securemesh_site_v2s
+    probe_method: GET
     notes: >-
-      NEVER APPLY THIS RENAME. 'blocked_sevice' is the live wire key.
-      Proven against the live API: a PUT whose body uses 'blocked_sevice'
-      returns HTTP 200 and the value round-trips on the subsequent GET,
-      while the correctly spelled 'blocked_service' is accepted by the
-      request parser but silently ignored -- the setting is never applied
-      and never returned. Renaming the property in the spec therefore
-      breaks every downstream consumer generated from it: the request
-      would carry a key the server drops on the floor, with no error.
-      A blind text replacement downstream did exactly this and broke the
-      field on the wire -- see terraform-provider-xcsh#1257. The rename
-      stays unapplied permanently; the typo must be fixed by F5 upstream,
-      with a server-side alias, before the spec can follow.
-      'never_apply: true' is enforced in code by the fix_property_names
-      transform and by verify_property_names, not by convention alone.
+      Re-probed 2026-07-25: HTTP 200, response carries
+      'blocked_sevice'. 7 occurrences.
+      THE WIRE KEY CAN NEVER MOVE. A PUT whose body uses
+      'blocked_sevice' returns HTTP 200 and round-trips on
+      the subsequent GET, while the correctly spelled
+      'blocked_service' is accepted by the request parser
+      and then silently ignored -- never applied, never
+      returned. A blind text replacement downstream did
+      exactly this and broke the field on the wire, see
+      terraform-provider-xcsh#1257. This entry may only
+      ever be presented under the corrected name with
+      x-f5xc-wire-name pinning 'blocked_sevice'; it must
+      never be promoted to fix_spec until F5 ships a
+      server-side alias upstream.
 
-  # --- Unverifiable on staging tenant ---
+  - schema: reportingTrafficOverviewData
+    old_key: previous_reqeust_count
+    new_key: previous_request_count
+    verified: true
+    api_status: upstream_typo
+    probe_endpoint: >-
+      /api/shape/bot/namespaces/{namespace}/v3/reporting/traffic/overview
+    probe_method: POST
+    notes: >-
+      Verified 2026-07-25 (was unverifiable on the staging
+      tenant): HTTP 200, traffic_type_data[] carries
+      'previous_reqeust_count'. Also in
+      reportingAutomationTypeData, whose probe
+      (top/type/malicious/dimension/automation) returned
+      HTTP 200 with an empty result set.
+
+  # --- Unverifiable: addon not provisioned on any reachable tenant ---
 
   - schema: recognizeRescueItem
     old_key: OBSOLOTE_upperBound
     new_key: OBSOLETE_upperBound
     verified: false
     api_status: unverifiable
-    probe_endpoint: >-
-      /api/shape/recognize/namespaces/system/
-      recognize/addon/dashboard/rescue
-    probe_method: POST
-    notes: >-
-      Shape API returned HTTP 403.
-      Needs Shape/Bot Defense entitlement.
-
-  - schema: reportingAutomationTypeData
-    old_key: previous_reqeust_count
-    new_key: previous_request_count
-    verified: false
-    api_status: unverifiable
-    probe_endpoint: >-
-      /api/data/namespaces/system/bot_defense_overview
+    probe_endpoint: /api/shape/recognize/namespaces/system/recognize/addon/state
     probe_method: GET
     notes: >-
-      Bot Defense reporting returned HTTP 404.
-      Needs Shape/Bot Defense entitlement.
+      Re-probed 2026-07-25 on f5-amer-ent: every Shape
+      Recognize operation returns HTTP 503 (addon/state,
+      addon/provision, dashboard/health, dashboard/rescue,
+      dashboard/lift). 'shape-recognize' is listed by
+      GET /api/web/namespaces/system/addon_services but is
+      not provisioned, and addon_subscriptions returns
+      HTTP 403, so entitlement cannot even be read. The
+      wire key is preserved, so this costs nothing.

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -48,6 +48,25 @@ SCHEMA_REF_PREFIX = "#/components/schemas/"
 # unimplemented one fails loudly instead of silently doing nothing.
 STUB_REMEDY = "stub"
 
+# Extension that records the JSON key F5's live API accepts on the wire.
+# Emitted whenever a misspelled property is renamed for presentation but the
+# platform still requires the original key in requests and responses.
+WIRE_NAME_EXTENSION = "x-f5xc-wire-name"
+
+# ``api_status`` value meaning the live API itself uses the corrected key, so
+# renaming changes the wire too and no wire-name annotation is needed.
+FIX_SPEC_STATUS = "fix_spec"
+
+# Prefix of the schema-level extensions whose value enumerates the member
+# property names of a ``oneof`` group.  F5 emits the list as a JSON-encoded
+# string (``"[\"a\",\"b\"]"``), so a renamed member has to be rewritten there
+# too or the group stops naming a property that exists.
+ONEOF_FIELD_PREFIX = "x-ves-oneof-field-"
+
+# Presentation strings that mirror the property key verbatim in some F5
+# schemas; they follow the rename so the typo does not resurface in docs.
+_MIRRORED_LABEL_KEYS = ("title", "x-displayname")
+
 # ---------------------------------------------------------------------------
 # Transform registry
 # ---------------------------------------------------------------------------
@@ -188,6 +207,69 @@ def _rewrite_refs(obj: Any, old_ref: str, new_ref: str) -> int:
         for item in obj:
             count += _rewrite_refs(item, old_ref, new_ref)
     return count
+
+
+def _preserves_wire_key(rule: dict) -> bool:
+    """Return ``True`` when F5's API still requires the misspelled key.
+
+    Only a correction that has been verified against the live API *and* found
+    to use the corrected key (``api_status: fix_spec``) may change the wire.
+    Everything else -- an upstream platform typo, or a correction nobody has
+    been able to probe -- keeps the original key so requests stay byte
+    identical to what the platform accepts today.
+    """
+    return not (rule.get("verified", False) and rule.get("api_status") == FIX_SPEC_STATUS)
+
+
+def _rename_key_in_place(mapping: dict, old_key: str, new_key: str) -> dict:
+    """Return a copy of *mapping* with *old_key* renamed, keeping its position."""
+    return {(new_key if key == old_key else key): value for key, value in mapping.items()}
+
+
+def _rename_schema_property(
+    schema_def: dict,
+    old_key: str,
+    new_key: str,
+    wire_name: str | None,
+) -> bool:
+    """Rename one misspelled property everywhere *schema_def* names it.
+
+    Covers the ``properties`` key itself, any mention in ``required``, and any
+    ``x-ves-oneof-field-*`` group that lists the property by name.  When
+    *wire_name* is given it is recorded on the renamed property so downstream
+    consumers can present the corrected name while marshalling the original.
+
+    Returns ``True`` when the schema declared *old_key* and was rewritten.  A
+    schema that already declares *new_key* is left alone: the two keys are
+    distinct fields and renaming would silently destroy one of them.
+    """
+    props = schema_def.get("properties")
+    if not isinstance(props, dict) or old_key not in props or new_key in props:
+        return False
+
+    schema_def["properties"] = _rename_key_in_place(props, old_key, new_key)
+
+    prop = schema_def["properties"][new_key]
+    if isinstance(prop, dict):
+        for label_key in _MIRRORED_LABEL_KEYS:
+            if prop.get(label_key) == old_key:
+                prop[label_key] = new_key
+        if wire_name is not None:
+            prop[WIRE_NAME_EXTENSION] = wire_name
+
+    required = schema_def.get("required")
+    if isinstance(required, list):
+        schema_def["required"] = [new_key if entry == old_key else entry for entry in required]
+
+    for ext_key, ext_value in list(schema_def.items()):
+        if not ext_key.startswith(ONEOF_FIELD_PREFIX):
+            continue
+        if isinstance(ext_value, str):
+            schema_def[ext_key] = ext_value.replace(f'"{old_key}"', f'"{new_key}"')
+        elif isinstance(ext_value, list):
+            schema_def[ext_key] = [new_key if entry == old_key else entry for entry in ext_value]
+
+    return True
 
 
 def _collect_refs(obj: Any) -> set[str]:
@@ -569,11 +651,25 @@ def fix_property_names(
     config: TransformConfig,
     _filename: str,
 ) -> dict:
-    """Rename misspelled JSON property keys in component schemas.
+    """Correct misspelled JSON property names in component schemas.
 
-    Only applies corrections marked ``verified: true`` in the config. A rule
-    flagged ``never_apply: true`` is skipped unconditionally: the live API
-    requires the misspelled key, so renaming it would break the wire contract.
+    Every tracked correction fixes the *presented* name -- the Terraform
+    attribute, MCP field and documentation label that consumers see.  Where
+    F5's platform still requires the misspelling on the wire, the renamed
+    property carries ``x-f5xc-wire-name`` holding the original key verbatim,
+    so no consumer has to hard-code the typo and no request changes shape.
+
+    The ``schema`` recorded on each correction names the schema the typo was
+    probed against; the rename is applied to every schema that declares the
+    key, because F5 repeats the same misspelled field across sibling schemas
+    and files.
+
+    This supersedes the ``never_apply`` flag.  ``never_apply`` protected the
+    wire key by refusing to rename at all, which also meant the typo stayed
+    in every generated consumer.  The wire key is now protected structurally
+    instead: ``api_status`` decides whether the rename reaches the wire, and
+    anything short of a verified ``fix_spec`` keeps the original key in
+    ``x-f5xc-wire-name``.
     """
     corrections = config.metadata.get("property_name_corrections", [])
     if not corrections:
@@ -581,27 +677,13 @@ def fix_property_names(
 
     schemas = spec.get("components", {}).get("schemas", {})
     for rule in corrections:
-        if rule.get("never_apply", False):
-            continue
-        if not rule.get("verified", False):
-            continue
-        schema_name = rule["schema"]
         old_key = rule["old_key"]
         new_key = rule["new_key"]
+        wire_name = old_key if _preserves_wire_key(rule) else None
 
-        schema_def = schemas.get(schema_name)
-        if schema_def is None:
-            continue
-
-        props = schema_def.get("properties", {})
-        if old_key not in props:
-            continue
-
-        props[new_key] = props.pop(old_key)
-
-        required = schema_def.get("required", [])
-        if old_key in required:
-            required[required.index(old_key)] = new_key
+        for schema_def in schemas.values():
+            if isinstance(schema_def, dict):
+                _rename_schema_property(schema_def, old_key, new_key, wire_name)
 
     return spec
 

--- a/scripts/verify_property_names.py
+++ b/scripts/verify_property_names.py
@@ -25,6 +25,19 @@ VALIDATION_CONFIG_PATH = Path("config/validation.yaml")
 
 HTTP_OK = 200
 
+# Probe outcomes that are a real observation of the live API, and so may be
+# written back to the config as `verified`.  Anything else (an HTTP error, a
+# response carrying neither key, both keys at once) leaves the entry alone.
+OBSERVED_STATUSES = frozenset({"fix_spec", "upstream_typo"})
+
+# `upstream_typo_permanent` is a stronger claim than a read probe can make or
+# unmake: it records that the corrected key is *silently ignored on write*, a
+# fact only a round-tripped PUT establishes.  It is therefore sticky -- no
+# probe outcome may overwrite it, in either direction.  Promoting such an
+# entry to `fix_spec` would move the wire key onto a name the platform drops
+# on the floor without erroring (see terraform-provider-xcsh#1257).
+PERMANENT_TYPO_STATUS = "upstream_typo_permanent"
+
 
 def _search_keys(obj: Any, target_key: str) -> bool:
     """Recursively search for a key name anywhere in a JSON structure."""
@@ -48,7 +61,7 @@ def _probe_correction(
     """
     old_key = correction["old_key"]
     new_key = correction["new_key"]
-    endpoint = correction["probe_endpoint"]
+    endpoint = correction["probe_endpoint"].replace("{namespace}", auth.namespace)
     method = correction.get("probe_method", "GET")
 
     result = {
@@ -105,23 +118,43 @@ def _probe_correction(
     return result
 
 
+def _observed_status(correction: dict, probe_status: str) -> str:
+    """Return the ``api_status`` to record for *correction* after a probe.
+
+    ``upstream_typo_permanent`` is sticky: a read probe cannot establish or
+    overturn "the corrected key is silently ignored on write", so it must
+    neither downgrade the entry to a plain ``upstream_typo`` nor promote it to
+    ``fix_spec``.
+    """
+    if correction.get("api_status") == PERMANENT_TYPO_STATUS:
+        return PERMANENT_TYPO_STATUS
+    return probe_status
+
+
 def _update_config(corrections: list[dict], results: list[dict]) -> bool:
-    """Update the corrections config file with verification results."""
+    """Record what each probe observed on the matching correction entries.
+
+    Both outcomes are worth recording: ``fix_spec`` unlocks an outright
+    rename, and ``upstream_typo`` proves the wire key must be preserved.  An
+    entry left ``verified: false`` therefore means the API could not be
+    observed at all, never that nobody looked.
+    """
     changed = False
     for result in results:
-        if result["status"] != "fix_spec":
+        if result["status"] not in OBSERVED_STATUSES:
             continue
         for correction in corrections:
-            if correction.get("never_apply", False):
-                # Wire contract depends on the misspelled key -- never promote.
-                continue
             if (
-                correction["schema"] == result["schema"]
-                and correction["old_key"] == result["old_key"]
-                and not correction.get("verified", False)
+                correction["schema"] != result["schema"]
+                or correction["old_key"] != result["old_key"]
             ):
-                correction["verified"] = True
-                changed = True
+                continue
+            status = _observed_status(correction, result["status"])
+            if correction.get("verified", False) and correction.get("api_status") == status:
+                continue
+            correction["verified"] = True
+            correction["api_status"] = status
+            changed = True
     return changed
 
 

--- a/tests/test_property_name_corrections.py
+++ b/tests/test_property_name_corrections.py
@@ -1,0 +1,269 @@
+"""Acceptance tests for property name corrections against the released specs.
+
+These run the ``fix_property_names`` transform over the real
+``config/property_name_corrections.yaml`` and the real ``release/specs``
+files, and assert both halves of the contract for every tracked correction:
+
+* the **presented** name is corrected, everywhere the specs name it, and
+* the **wire** key is byte-identical to what F5's platform accepts today.
+
+No misspelled key is written out in this module; every one is read from the
+config, which is the single source of truth.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.transform import (
+    FIX_SPEC_STATUS,
+    ONEOF_FIELD_PREFIX,
+    WIRE_NAME_EXTENSION,
+    TransformConfig,
+    fix_property_names,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "config" / "property_name_corrections.yaml"
+SPECS_DIR = REPO_ROOT / "release" / "specs"
+
+
+def _load_corrections() -> list[dict]:
+    with CONFIG_PATH.open() as fh:
+        return (yaml.safe_load(fh) or {}).get("corrections", [])
+
+
+CORRECTIONS = _load_corrections()
+CORRECTION_IDS = [c["old_key"] for c in CORRECTIONS]
+
+
+def _changes_the_wire(correction: dict) -> bool:
+    """True when the rename is also a wire change (the API uses the fix)."""
+    return correction.get("verified", False) and correction.get("api_status") == FIX_SPEC_STATUS
+
+
+def _affected_spec_paths() -> list[Path]:
+    """Return the released specs that mention at least one tracked typo."""
+    tokens = [f'"{c["old_key"]}"' for c in CORRECTIONS]
+    return [
+        path
+        for path in sorted(SPECS_DIR.glob("*.json"))
+        if any(token in path.read_text() for token in tokens)
+    ]
+
+
+@pytest.fixture(scope="module")
+def transformed_specs() -> list[tuple[str, dict, dict]]:
+    """Return ``(filename, original, transformed)`` for every affected spec."""
+    config = TransformConfig(metadata={"property_name_corrections": CORRECTIONS})
+    results = []
+    for path in _affected_spec_paths():
+        with path.open() as fh:
+            original = json.load(fh)
+        transformed = fix_property_names(copy.deepcopy(original), config, path.name)
+        results.append((path.name, original, transformed))
+    return results
+
+
+def _schemas(spec: dict) -> dict:
+    return spec.get("components", {}).get("schemas", {})
+
+
+def _wire_keys(schema_def: dict) -> set[str]:
+    """Return the JSON keys a schema puts on the wire."""
+    keys = set()
+    for name, prop in schema_def.get("properties", {}).items():
+        if isinstance(prop, dict) and WIRE_NAME_EXTENSION in prop:
+            keys.add(prop[WIRE_NAME_EXTENSION])
+        else:
+            keys.add(name)
+    return keys
+
+
+def _declaring_schemas(old_key: str, specs: list[tuple[str, dict, dict]]) -> list[tuple[str, str]]:
+    """Return ``(filename, schema_name)`` for every schema declaring *old_key*."""
+    return [
+        (name, schema_name)
+        for name, original, _ in specs
+        for schema_name, schema in _schemas(original).items()
+        if old_key in schema.get("properties", {})
+    ]
+
+
+def _corrected_schemas(new_key: str, specs: list[tuple[str, dict, dict]]) -> list[tuple[str, str]]:
+    """Return ``(filename, schema_name)`` for every schema already using *new_key*.
+
+    The published artifact is pipeline *output*, so a correction the pipeline
+    already applies to the wire (a verified ``fix_spec``) is absent from it as
+    the typo and present as the fix. That is success, not dead config.
+    """
+    return [
+        (name, schema_name)
+        for name, original, _ in specs
+        for schema_name, schema in _schemas(original).items()
+        if new_key in schema.get("properties", {})
+    ]
+
+
+def _string_values(obj: Any) -> list[str]:
+    """Collect every string value reachable in *obj*."""
+    if isinstance(obj, dict):
+        return [s for value in obj.values() for s in _string_values(value)]
+    if isinstance(obj, list):
+        return [s for item in obj for s in _string_values(item)]
+    if isinstance(obj, str):
+        return [obj]
+    return []
+
+
+class TestCorrectionsConfig:
+    def test_config_declares_corrections(self):
+        assert CORRECTIONS, f"no corrections loaded from {CONFIG_PATH}"
+
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_every_entry_is_fully_specified(self, correction):
+        for field in ("schema", "old_key", "new_key", "verified", "api_status"):
+            assert field in correction, f"{correction.get('old_key')} lacks {field}"
+        assert correction["api_status"] in {
+            FIX_SPEC_STATUS,
+            "upstream_typo",
+            "upstream_typo_permanent",
+            "unverifiable",
+        }
+
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_unverified_entries_are_unverifiable_not_unchecked(self, correction):
+        if not correction["verified"]:
+            assert correction["api_status"] == "unverifiable"
+            assert correction.get("notes"), "an unverifiable entry must say why"
+
+
+class TestReleasedSpecsAreCorrected:
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_correction_matches_a_released_spec(self, correction, transformed_specs):
+        """A tracked correction the artifact knows nothing about is dead config."""
+        old_key, new_key = correction["old_key"], correction["new_key"]
+        assert _declaring_schemas(old_key, transformed_specs) or _corrected_schemas(
+            new_key, transformed_specs
+        ), f"neither {old_key} nor {new_key} is declared by any released spec"
+
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_presented_name_is_corrected(self, correction, transformed_specs):
+        old_key, new_key = correction["old_key"], correction["new_key"]
+        declaring = _declaring_schemas(old_key, transformed_specs)
+        if not declaring:
+            assert _corrected_schemas(new_key, transformed_specs), (
+                f"{old_key} vanished from the artifact without {new_key} taking its place"
+            )
+            return
+        for name, schema_name in declaring:
+            after = next(
+                _schemas(t)[schema_name]["properties"]
+                for filename, _o, t in transformed_specs
+                if filename == name
+            )
+            assert old_key not in after, f"{name}/{schema_name} kept {old_key}"
+            assert new_key in after, f"{name}/{schema_name} lacks {new_key}"
+
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_wire_key_is_preserved(self, correction, transformed_specs):
+        old_key, new_key = correction["old_key"], correction["new_key"]
+        declaring = _declaring_schemas(old_key, transformed_specs)
+        if not declaring:
+            # The typo is gone from the published artifact, so the wire key
+            # already moved. Only a verified ``fix_spec`` may do that; for any
+            # other status this is the regression that broke the field on the
+            # wire downstream (terraform-provider-xcsh#1257).
+            assert _changes_the_wire(correction), (
+                f"{old_key} is absent from the published specs but its status "
+                f"is {correction['api_status']!r} -- the wire key moved off a "
+                "key the platform still requires"
+            )
+            return
+        for name, schema_name in declaring:
+            prop = next(
+                _schemas(t)[schema_name]["properties"][new_key]
+                for filename, _o, t in transformed_specs
+                if filename == name
+            )
+            if _changes_the_wire(correction):
+                assert WIRE_NAME_EXTENSION not in prop, (
+                    f"{name}/{schema_name}: a verified fix_spec rename must not pin a wire name"
+                )
+            else:
+                assert prop[WIRE_NAME_EXTENSION] == old_key, (
+                    f"{name}/{schema_name}: wire key moved off {old_key}"
+                )
+
+    @pytest.mark.parametrize("correction", CORRECTIONS, ids=CORRECTION_IDS)
+    def test_no_string_reference_to_the_typo_survives(self, correction, transformed_specs):
+        """`required` and `x-ves-oneof-field-*` name properties by string."""
+        old_key = correction["old_key"]
+        for name, _original, transformed in transformed_specs:
+            for schema_name, schema in _schemas(transformed).items():
+                assert old_key not in schema.get("required", []), (
+                    f"{name}/{schema_name}: required still names {old_key}"
+                )
+                for key, value in schema.items():
+                    if not key.startswith(ONEOF_FIELD_PREFIX):
+                        continue
+                    assert old_key not in _string_values(value), (
+                        f"{name}/{schema_name}/{key} still names {old_key}"
+                    )
+                    if isinstance(value, str):
+                        assert f'"{old_key}"' not in value, (
+                            f"{name}/{schema_name}/{key} still names {old_key}"
+                        )
+
+
+class TestNothingElseMoves:
+    def test_no_wire_key_changes_anywhere(self, transformed_specs):
+        """Every schema must put exactly the same JSON keys on the wire.
+
+        The only permitted difference is a verified ``fix_spec`` correction,
+        where the live API uses the corrected key and the pre-change transform
+        already renamed it outright.
+        """
+        wire_renames = {c["old_key"]: c["new_key"] for c in CORRECTIONS if _changes_the_wire(c)}
+        for name, original, transformed in transformed_specs:
+            after = _schemas(transformed)
+            for schema_name, schema in _schemas(original).items():
+                expected = {wire_renames.get(key, key) for key in schema.get("properties", {})}
+                assert _wire_keys(after[schema_name]) == expected, (
+                    f"{name}/{schema_name}: wire keys changed"
+                )
+
+    def test_paths_operation_ids_and_refs_are_untouched(self, transformed_specs):
+        for name, original, transformed in transformed_specs:
+            assert transformed.get("paths") == original.get("paths"), name
+
+    def test_enum_values_are_untouched(self, transformed_specs):
+        for name, original, transformed in transformed_specs:
+            after = _schemas(transformed)
+            for schema_name, schema in _schemas(original).items():
+                for prop_name, prop in schema.get("properties", {}).items():
+                    if not isinstance(prop, dict) or "enum" not in prop:
+                        continue
+                    corrected = next(
+                        (c["new_key"] for c in CORRECTIONS if c["old_key"] == prop_name),
+                        prop_name,
+                    )
+                    assert after[schema_name]["properties"][corrected]["enum"] == prop["enum"], (
+                        f"{name}/{schema_name}/{prop_name}"
+                    )
+
+    def test_schema_names_are_untouched(self, transformed_specs):
+        for name, original, transformed in transformed_specs:
+            assert set(_schemas(transformed)) == set(_schemas(original)), name
+
+    def test_transform_is_idempotent(self, transformed_specs):
+        config = TransformConfig(metadata={"property_name_corrections": CORRECTIONS})
+        for name, _original, transformed in transformed_specs:
+            twice = fix_property_names(copy.deepcopy(transformed), config, name)
+            assert twice == transformed, f"{name} is not idempotent"

--- a/tests/test_spelling_corrections.py
+++ b/tests/test_spelling_corrections.py
@@ -27,6 +27,7 @@ import yaml
 
 from scripts.transform import (
     DEFAULT_SPELLING_TEXT_FIELDS,
+    WIRE_NAME_EXTENSION,
     TransformConfig,
     _build_spelling_patterns,
     fix_property_names,
@@ -145,6 +146,21 @@ def _property_names(obj: Any) -> set[str]:
     return names
 
 
+def _wire_name_annotations(obj: Any) -> set[str]:
+    """Return every wire key pinned by an ``x-f5xc-wire-name`` annotation."""
+    keys: set[str] = set()
+    if isinstance(obj, dict):
+        pinned = obj.get(WIRE_NAME_EXTENSION)
+        if isinstance(pinned, str):
+            keys.add(pinned)
+        for value in obj.values():
+            keys.update(_wire_name_annotations(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            keys.update(_wire_name_annotations(item))
+    return keys
+
+
 # ---------------------------------------------------------------------------
 # Invariant 1 -- the published artifact matches the configuration
 # ---------------------------------------------------------------------------
@@ -241,20 +257,35 @@ def test_corrections_never_match_an_identifier(
 def test_wire_contract_property_names_are_preserved(
     released_specs: list[tuple[str, dict]],
 ) -> None:
-    """``blocked_sevice`` and ``checkin`` still exist as property names."""
-    names: set[str] = set()
+    """``blocked_sevice`` and ``checkin`` survive as wire keys.
+
+    A wire key is carried either by the property name itself or, once
+    ``fix_property_names`` has corrected the presented name, by the
+    ``x-f5xc-wire-name`` annotation on the renamed property. Both count; the
+    invariant is that the key F5's platform requires is still expressed
+    somewhere the marshaller can find it.
+    """
+    keys: set[str] = set()
     for _filename, spec in released_specs:
-        names.update(_property_names(spec))
+        keys.update(_property_names(spec))
+        keys.update(_wire_name_annotations(spec))
 
     for wire_key in WIRE_CONTRACT_PROPERTY_NAMES:
-        assert wire_key in names, (
-            f"{wire_key!r} disappeared from the published specs. The live API "
-            f"requires this exact spelling; renaming it breaks the wire contract."
+        assert wire_key in keys, (
+            f"{wire_key!r} disappeared from the published specs, as a property "
+            f"name and as an {WIRE_NAME_EXTENSION} value. The live API requires "
+            f"this exact spelling; losing it breaks the wire contract."
         )
 
 
-def test_blocked_sevice_rename_is_marked_never_apply() -> None:
-    """The rename that breaks the wire contract stays permanently unapplied."""
+def test_permanent_wire_typo_is_recorded_as_such() -> None:
+    """The rename that must never reach the wire is flagged in the config.
+
+    ``blocked_service`` is accepted by the request parser and then silently
+    dropped, so this entry may only ever be *presented* under the corrected
+    name. ``upstream_typo_permanent`` is what pins that, and
+    ``verify_property_names`` treats it as sticky so no probe can promote it.
+    """
     with PROPERTY_CONFIG.open() as fh:
         cfg = yaml.safe_load(fh) or {}
 
@@ -262,14 +293,12 @@ def test_blocked_sevice_rename_is_marked_never_apply() -> None:
     assert len(rules) == 1, "expected exactly one blocked_sevice rule"
     rule = rules[0]
 
-    assert rule["never_apply"] is True
-    assert rule["verified"] is False
     assert rule["api_status"] == "upstream_typo_permanent"
-    assert "NEVER APPLY" in rule["notes"]
+    assert "never" in rule["notes"].lower()
 
 
-def test_never_apply_overrides_verified() -> None:
-    """``never_apply`` wins even if a rule is somehow marked verified."""
+def test_a_permanent_wire_typo_is_renamed_but_keeps_its_wire_key() -> None:
+    """The presented name is corrected; the wire key is pinned, not moved."""
     spec = {
         "components": {
             "schemas": {
@@ -288,7 +317,7 @@ def test_never_apply_overrides_verified() -> None:
                     "old_key": "blocked_sevice",
                     "new_key": "blocked_service",
                     "verified": True,
-                    "never_apply": True,
+                    "api_status": "upstream_typo_permanent",
                 }
             ]
         }
@@ -296,9 +325,10 @@ def test_never_apply_overrides_verified() -> None:
 
     result = fix_property_names(spec, config, "test.json")
     schema = result["components"]["schemas"]["fleetBlockedServicesListType"]
-    assert "blocked_sevice" in schema["properties"]
-    assert "blocked_service" not in schema["properties"]
-    assert schema["required"] == ["blocked_sevice"]
+
+    assert "blocked_sevice" not in schema["properties"]
+    assert schema["required"] == ["blocked_service"]
+    assert schema["properties"]["blocked_service"][WIRE_NAME_EXTENSION] == "blocked_sevice"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -9,10 +9,12 @@ import pytest
 from scripts.transform import (
     HTTP_METHODS,
     TRANSFORM_REGISTRY,
+    WIRE_NAME_EXTENSION,
     SpecTransformer,
     TransformConfig,
     deduplicate_operation_ids,
     fix_invalid_examples,
+    fix_property_names,
     inject_contact,
     inject_info_version,
     inject_operation_descriptions,
@@ -206,12 +208,8 @@ class TestInjectServers:
 
 
 class TestInjectSecuritySchemes:
-    def test_adds_security_scheme_and_global_security(
-        self, minimal_spec, config_with_metadata
-    ):
-        result = inject_security_schemes(
-            minimal_spec, config_with_metadata, "test.json"
-        )
+    def test_adds_security_scheme_and_global_security(self, minimal_spec, config_with_metadata):
+        result = inject_security_schemes(minimal_spec, config_with_metadata, "test.json")
         assert "components" in result
         assert "securitySchemes" in result["components"]
         assert "apiKeyAuth" in result["components"]["securitySchemes"]
@@ -295,9 +293,7 @@ class TestDeduplicateOperationIds:
         assert post_id == "getResource_post"
         assert del_id == "getResource_delete"
 
-    def test_same_method_duplicates_across_paths_get_index_suffix(
-        self, config_with_metadata
-    ):
+    def test_same_method_duplicates_across_paths_get_index_suffix(self, config_with_metadata):
         spec = {
             "openapi": "3.0.0",
             "info": {"title": "Test", "version": "1.0.0"},
@@ -327,12 +323,8 @@ class TestDeduplicateOperationIds:
             },
         }
         result = deduplicate_operation_ids(spec, config_with_metadata, "test.json")
-        assert (
-            result["paths"]["/api/resources"]["get"]["operationId"] == "listResources"
-        )
-        assert (
-            result["paths"]["/api/resources"]["post"]["operationId"] == "createResource"
-        )
+        assert result["paths"]["/api/resources"]["get"]["operationId"] == "listResources"
+        assert result["paths"]["/api/resources"]["post"]["operationId"] == "createResource"
 
 
 class TestStripScriptTags:
@@ -364,19 +356,14 @@ class TestStripScriptTags:
                 "/test": {
                     "get": {
                         "description": "<script>bad</script>OK",
-                        "responses": {
-                            "200": {"description": "Success <script>x</script>"}
-                        },
+                        "responses": {"200": {"description": "Success <script>x</script>"}},
                     }
                 }
             },
         }
         result = strip_script_tags(spec, config_with_metadata, "test.json")
         assert "<script>" not in result["paths"]["/test"]["get"]["description"]
-        assert (
-            "<script>"
-            not in result["paths"]["/test"]["get"]["responses"]["200"]["description"]
-        )
+        assert "<script>" not in result["paths"]["/test"]["get"]["responses"]["200"]["description"]
 
 
 class TestFixInvalidExamples:
@@ -435,9 +422,7 @@ class TestRenameCollidingSchemas:
                 }
             },
         }
-        result = rename_colliding_schemas(
-            spec, config_with_renames, "foo.operate.route.json"
-        )
+        result = rename_colliding_schemas(spec, config_with_renames, "foo.operate.route.json")
         assert "operateRouteRouteType" in result["components"]["schemas"]
         assert "routeRouteType" not in result["components"]["schemas"]
         ref = result["components"]["schemas"]["Other"]["properties"]["rt"]["$ref"]
@@ -454,9 +439,7 @@ class TestRenameCollidingSchemas:
                 }
             },
         }
-        result = rename_colliding_schemas(
-            spec, config_with_renames, "foo.schema.route.json"
-        )
+        result = rename_colliding_schemas(spec, config_with_renames, "foo.schema.route.json")
         assert "routeRouteType" in result["components"]["schemas"]
         assert "operateRouteRouteType" not in result["components"]["schemas"]
 
@@ -532,9 +515,7 @@ class TestRemoveUnusedSchemas:
                                 "description": "OK",
                                 "content": {
                                     "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/UsedSchema"
-                                        }
+                                        "schema": {"$ref": "#/components/schemas/UsedSchema"}
                                     }
                                 },
                             }
@@ -566,9 +547,7 @@ class TestRemoveUnusedSchemas:
                                 "description": "OK",
                                 "content": {
                                     "application/json": {
-                                        "schema": {
-                                            "$ref": "#/components/schemas/Parent"
-                                        }
+                                        "schema": {"$ref": "#/components/schemas/Parent"}
                                     }
                                 },
                             }
@@ -603,9 +582,7 @@ class TestRemoveUnusedSchemas:
 
     def test_no_schemas_is_noop(self, minimal_spec, config_with_metadata):
         result = remove_unused_schemas(minimal_spec, config_with_metadata, "test.json")
-        assert "components" not in result or "schemas" not in result.get(
-            "components", {}
-        )
+        assert "components" not in result or "schemas" not in result.get("components", {})
 
 
 class TestInjectOperationDescriptions:
@@ -637,13 +614,225 @@ class TestInjectOperationDescriptions:
             },
         }
         result = inject_operation_descriptions(spec, config_with_metadata, "test.json")
-        assert (
-            result["paths"]["/api/test"]["get"]["description"]
-            == "Existing description."
-        )
+        assert result["paths"]["/api/test"]["get"]["description"] == "Existing description."
 
 
 class TestHTTPMethodsConstant:
     def test_http_methods_includes_all_standard_methods(self):
         expected = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
         assert expected == HTTP_METHODS
+
+
+# ---------------------------------------------------------------------------
+# fix_property_names
+#
+# Misspelled property names are never spelled out in this module: they are
+# read from ``config/property_name_corrections.yaml``, which is the single
+# source of truth (and which the spell checker skips).  Unit tests use
+# invented typos instead.
+# ---------------------------------------------------------------------------
+
+TYPO_KEY = "widget_naem"
+FIXED_KEY = "widget_name"
+OTHER_TYPO_KEY = "gadget_kolor"
+OTHER_FIXED_KEY = "gadget_color"
+
+
+def _corrections_config(*corrections: dict) -> TransformConfig:
+    return TransformConfig(
+        metadata={"property_name_corrections": list(corrections)},
+    )
+
+
+def _wire_preserving_rule() -> dict:
+    return {
+        "schema": "WidgetSpec",
+        "old_key": TYPO_KEY,
+        "new_key": FIXED_KEY,
+        "verified": True,
+        "api_status": "upstream_typo",
+    }
+
+
+def _fix_spec_rule() -> dict:
+    return {
+        "schema": "WidgetSpec",
+        "old_key": TYPO_KEY,
+        "new_key": FIXED_KEY,
+        "verified": True,
+        "api_status": "fix_spec",
+    }
+
+
+def _widget_spec(**schema_extras) -> dict:
+    schema = {
+        "type": "object",
+        "properties": {
+            "alpha": {"type": "string"},
+            TYPO_KEY: {"type": "string", "title": TYPO_KEY, "x-displayname": TYPO_KEY},
+            "omega": {"type": "string"},
+        },
+    }
+    schema.update(schema_extras)
+    return {"components": {"schemas": {"WidgetSpec": schema}}}
+
+
+class TestFixPropertyNames:
+    def test_no_corrections_is_a_no_op(self):
+        spec = _widget_spec()
+        result = fix_property_names(spec, TransformConfig(), "test.json")
+        assert TYPO_KEY in result["components"]["schemas"]["WidgetSpec"]["properties"]
+
+    def test_fix_spec_correction_renames_without_a_wire_name(self):
+        result = fix_property_names(
+            _widget_spec(), _corrections_config(_fix_spec_rule()), "test.json"
+        )
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert TYPO_KEY not in props
+        assert FIXED_KEY in props
+        assert WIRE_NAME_EXTENSION not in props[FIXED_KEY]
+
+    def test_upstream_typo_renames_and_records_the_wire_name(self):
+        result = fix_property_names(
+            _widget_spec(), _corrections_config(_wire_preserving_rule()), "test.json"
+        )
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert TYPO_KEY not in props
+        assert props[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    @pytest.mark.parametrize(
+        "api_status", ["upstream_typo", "upstream_typo_permanent", "unverifiable"]
+    )
+    def test_every_wire_preserving_status_records_the_wire_name(self, api_status):
+        rule = _wire_preserving_rule()
+        rule["api_status"] = api_status
+        result = fix_property_names(_widget_spec(), _corrections_config(rule), "test.json")
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert props[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    def test_unverified_fix_spec_still_preserves_the_wire_key(self):
+        rule = _fix_spec_rule()
+        rule["verified"] = False
+        result = fix_property_names(_widget_spec(), _corrections_config(rule), "test.json")
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert props[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    def test_required_entry_is_renamed(self):
+        spec = _widget_spec(required=["alpha", TYPO_KEY])
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        assert result["components"]["schemas"]["WidgetSpec"]["required"] == [
+            "alpha",
+            FIXED_KEY,
+        ]
+
+    def test_oneof_field_json_string_list_is_rewritten(self):
+        spec = _widget_spec(**{"x-ves-oneof-field-widget_choice": f'["{TYPO_KEY}","other"]'})
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        schema = result["components"]["schemas"]["WidgetSpec"]
+        assert schema["x-ves-oneof-field-widget_choice"] == f'["{FIXED_KEY}","other"]'
+
+    def test_oneof_field_array_is_rewritten(self):
+        spec = _widget_spec(**{"x-ves-oneof-field-widget_choice": [TYPO_KEY, "other"]})
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        schema = result["components"]["schemas"]["WidgetSpec"]
+        assert schema["x-ves-oneof-field-widget_choice"] == [FIXED_KEY, "other"]
+
+    def test_property_keeps_its_position(self):
+        result = fix_property_names(
+            _widget_spec(), _corrections_config(_wire_preserving_rule()), "test.json"
+        )
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert list(props) == ["alpha", FIXED_KEY, "omega"]
+
+    def test_mirrored_title_and_displayname_follow_the_rename(self):
+        result = fix_property_names(
+            _widget_spec(), _corrections_config(_wire_preserving_rule()), "test.json"
+        )
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert prop["title"] == FIXED_KEY
+        assert prop["x-displayname"] == FIXED_KEY
+
+    def test_unrelated_title_text_is_left_alone(self):
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY]["title"] = (
+            "Some Human Title"
+        )
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert prop["title"] == "Some Human Title"
+
+    def test_every_schema_declaring_the_property_is_renamed(self):
+        spec = _widget_spec()
+        spec["components"]["schemas"]["SiblingSpec"] = {
+            "type": "object",
+            "properties": {TYPO_KEY: {"type": "string"}},
+        }
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        sibling = result["components"]["schemas"]["SiblingSpec"]["properties"]
+        assert sibling[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    def test_existing_corrected_key_is_never_clobbered(self):
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY] = {"type": "integer"}
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert props[TYPO_KEY] == {
+            "type": "string",
+            "title": TYPO_KEY,
+            "x-displayname": TYPO_KEY,
+        }
+        assert props[FIXED_KEY] == {"type": "integer"}
+
+    def test_enum_values_paths_operation_ids_and_refs_are_untouched(self):
+        spec = _widget_spec()
+        spec["paths"] = {
+            f"/api/{TYPO_KEY}": {
+                "get": {
+                    "operationId": f"ves.io.schema.Get{TYPO_KEY}",
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": f"#/components/schemas/{TYPO_KEY}"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        }
+        spec["components"]["schemas"]["WidgetSpec"]["properties"]["alpha"]["enum"] = [
+            TYPO_KEY,
+            "other",
+        ]
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        operation = result["paths"][f"/api/{TYPO_KEY}"]["get"]
+        assert operation["operationId"] == f"ves.io.schema.Get{TYPO_KEY}"
+        assert (
+            operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+            == f"#/components/schemas/{TYPO_KEY}"
+        )
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert props["alpha"]["enum"] == [TYPO_KEY, "other"]
+
+    def test_multiple_corrections_apply_independently(self):
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][OTHER_TYPO_KEY] = {
+            "type": "string"
+        }
+        other = {
+            "schema": "WidgetSpec",
+            "old_key": OTHER_TYPO_KEY,
+            "new_key": OTHER_FIXED_KEY,
+            "verified": True,
+            "api_status": "fix_spec",
+        }
+        result = fix_property_names(
+            spec,
+            _corrections_config(_wire_preserving_rule(), other),
+            "test.json",
+        )
+        props = result["components"]["schemas"]["WidgetSpec"]["properties"]
+        assert props[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
+        assert WIRE_NAME_EXTENSION not in props[OTHER_FIXED_KEY]

--- a/tests/test_verify_property_names.py
+++ b/tests/test_verify_property_names.py
@@ -1,0 +1,100 @@
+"""Tests for recording live-API observations on property name corrections."""
+
+from __future__ import annotations
+
+from scripts.verify_property_names import _observed_status, _update_config
+
+SCHEMA = "WidgetSpec"
+TYPO_KEY = "widget_naem"
+FIXED_KEY = "widget_name"
+
+
+def _correction(**overrides) -> dict:
+    correction = {
+        "schema": SCHEMA,
+        "old_key": TYPO_KEY,
+        "new_key": FIXED_KEY,
+        "verified": False,
+        "api_status": "unverifiable",
+    }
+    correction.update(overrides)
+    return correction
+
+
+def _result(status: str) -> dict:
+    return {
+        "schema": SCHEMA,
+        "old_key": TYPO_KEY,
+        "new_key": FIXED_KEY,
+        "status": status,
+    }
+
+
+class TestUpdateConfig:
+    def test_fix_spec_marks_verified_and_records_the_status(self):
+        corrections = [_correction()]
+        assert _update_config(corrections, [_result("fix_spec")]) is True
+        assert corrections[0]["verified"] is True
+        assert corrections[0]["api_status"] == "fix_spec"
+
+    def test_upstream_typo_also_earns_verification(self):
+        """Confirming the typo is a real observation, not a failed probe."""
+        corrections = [_correction()]
+        assert _update_config(corrections, [_result("upstream_typo")]) is True
+        assert corrections[0]["verified"] is True
+        assert corrections[0]["api_status"] == "upstream_typo"
+
+    def test_permanent_typo_is_not_downgraded(self):
+        corrections = [_correction(verified=True, api_status="upstream_typo_permanent")]
+        assert _update_config(corrections, [_result("upstream_typo")]) is False
+        assert corrections[0]["api_status"] == "upstream_typo_permanent"
+
+    def test_permanent_typo_is_never_promoted_to_fix_spec(self):
+        """A read probe must not unlock a rename the platform ignores on write.
+
+        ``blocked_service`` is accepted by the request parser and then dropped,
+        so a GET that happens to surface the corrected key is not evidence the
+        wire key may move -- see terraform-provider-xcsh#1257.
+        """
+        corrections = [_correction(verified=True, api_status="upstream_typo_permanent")]
+        assert _update_config(corrections, [_result("fix_spec")]) is False
+        assert corrections[0]["api_status"] == "upstream_typo_permanent"
+
+    def test_unusable_probe_leaves_the_entry_alone(self):
+        for status in (
+            "http_403",
+            "http_503",
+            "neither_found",
+            "both_present",
+            "error",
+        ):
+            corrections = [_correction()]
+            assert _update_config(corrections, [_result(status)]) is False
+            assert corrections[0]["verified"] is False
+            assert corrections[0]["api_status"] == "unverifiable"
+
+    def test_already_recorded_observation_is_not_rewritten(self):
+        corrections = [_correction(verified=True, api_status="upstream_typo")]
+        assert _update_config(corrections, [_result("upstream_typo")]) is False
+
+    def test_a_changed_observation_is_recorded(self):
+        """F5 fixing the platform must flip the entry back to fix_spec."""
+        corrections = [_correction(verified=True, api_status="upstream_typo")]
+        assert _update_config(corrections, [_result("fix_spec")]) is True
+        assert corrections[0]["api_status"] == "fix_spec"
+
+    def test_only_the_matching_entry_is_touched(self):
+        other = _correction(old_key="gadget_kolor", new_key="gadget_color")
+        corrections = [_correction(), other]
+        _update_config(corrections, [_result("upstream_typo")])
+        assert other["verified"] is False
+
+
+class TestObservedStatus:
+    def test_permanent_typo_survives_a_confirming_probe(self):
+        correction = _correction(api_status="upstream_typo_permanent")
+        assert _observed_status(correction, "upstream_typo") == "upstream_typo_permanent"
+
+    def test_permanent_typo_survives_a_fix_spec_probe(self):
+        correction = _correction(api_status="upstream_typo_permanent")
+        assert _observed_status(correction, "fix_spec") == "upstream_typo_permanent"


### PR DESCRIPTION
## ⚠️ DRAFT — must not merge before the downstream consumer lands. See "Sequencing".

## What
Stops exporting F5's misspelled property names to end users, without changing a single byte on the wire.

`config/property_name_corrections.yaml` tracked 8 misspelled properties, but `fix_property_names` only renamed when `verified: true` and skipped `never_apply: true` — so **6 passed through uncorrected** and users had to write `blocked_sevice`, `public_advertisment`, `disable_lb_source_ip_persistance` forever. `never_apply` and `unverifiable` were both functioning as *ignore*.

Now: the property is renamed to the correct spelling **and** annotated `x-f5xc-wire-name: <original>` whenever the live API requires the misspelling. The presented name is always corrected; only the wire key is preserved.

| presented before | presented after | wire key | annotations |
|---|---|---|---|
| `lables` | `labels` | `labels` (genuine spec bug) | — |
| `volterra_software_overide` | `volterra_software_override` | unchanged | 2 |
| `disable_lb_source_ip_persistance` | `…_persistence` | unchanged | 3 |
| `enable_lb_source_ip_persistance` | `…_persistence` | unchanged | 3 |
| `public_advertisment` | `public_advertisement` | unchanged | 8 |
| `public_advertisment_enabled` **(new)** | `public_advertisement_enabled` | unchanged | 1 |
| `blocked_sevice` | `blocked_service` | unchanged | 7 |
| `previous_reqeust_count` | `previous_request_count` | unchanged | 2 |
| `OBSOLOTE_upperBound` | `OBSOLETE_upperBound` | unchanged | 1 |

**Acceptance re-proved** over the 14 affected released specs: `old_key` occurrences after transform **0**; `new_key` **109**; `x-f5xc-wire-name` **27**, exactly 1:1 with the 27 non-`fix_spec` declarations. Wire keys in `release/` unchanged — `blocked_sevice` 7, `checkin` 4.

## "Unverifiable" is no longer a resting state
Both previously-unverifiable entries were probed live, read-only:
- **`previous_reqeust_count` → now verified** as `upstream_typo`: `POST …/v3/reporting/traffic/overview` returns HTTP 200 containing `"previous_reqeust_count":"0"`.
- **`OBSOLOTE_upperBound` → unverifiable, earned**: every Shape Recognize operation returns 503 (addon unprovisioned), `GET /addon_subscriptions` returns 403 so entitlement cannot even be read, and provisioning is a write that was deliberately not performed.

Re-probing the other seven also uncovered that several existing `probe_endpoint` values were **folded YAML split mid-path**, producing URLs containing a space — those probes could never have succeeded, which likely explains some recorded 403/404s. All six entries that asserted API behaviour while sitting at `verified: false` now carry real evidence.

## Guard strengthened rather than removed
This design retires the `never_apply` flag, which #679 had just introduced along with two tests. Those tests were re-expressed against the new mechanism instead of deleted, and the guarantee is now **stronger**: `upstream_typo_permanent` is sticky in `verify_property_names`, so no probe can promote it. Previously it only resisted downgrade — a `fix_spec` probe result could have moved the wire key.

## Sequencing — why this is a draft
`x-f5xc-wire-name` has **no consumer yet**. The spec now presents `blocked_service` with the wire key in an annotation. Until `terraform-provider-xcsh` honours the annotation, any generator that ignores it would emit `blocked_service` on the wire — which F5 silently ignores. That is exactly f5-sales-demo/terraform-provider-xcsh#1257, the bug this whole effort exists to prevent.

`release/specs` is deliberately **untouched** by this PR (0 files), and api-specs#680 currently blocks publishing anyway. The safe order is **consumer first**: land provider support for the annotation (harmless while no spec carries it), then merge this, then regenerate.

## Tests / gates
`make test` **224 passed / 1 skipped / 0 failed**. New: `TestFixPropertyNames` (16), `tests/test_property_name_corrections.py` (data-driven over the real config × real `release/specs`), `tests/test_verify_property_names.py` (9). No misspelled key is hard-coded in any `.py`. ruff check, mypy, codespell, yamllint, actionlint all pass; `pre-commit run --files` clean.

**Pre-existing breakage, not introduced here** (proven by `git archive origin/main` stash-and-compare): `ruff format --check` reports **19** files on untouched `main` and **18** on this branch — zero new, one fixed (`tests/test_transform.py`). Those 18 are untouched files formatted at ~88 against a configured line-length of 100; that needs its own issue and PR rather than being absorbed here.

## Consumers are in place — safe to merge

Both halves of the contract landed first, so nothing regresses when the renames ship:

- `terraform-provider-xcsh#1324` (**merged**) — codegen honours `x-f5xc-wire-name`: the Terraform attribute and docs use the corrected name, marshal/unmarshal use the wire key. Verified across all ten emission paths, with byte-identical output for un-annotated properties.
- `api-specs-enriched#1085` (**merged**) — the extension is registered and, critically, projected into `release/api-catalog.json` (`wireName`). An audit found that allowlist was silently dropping it, which would have made `xcsh` send corrected keys that F5 discards.

The release gate is also fixed (#680, merged), so this repo can publish again.

Closes #686
