### PR TITLE
feat: dispatch upstream-specs-released to api-specs-enriched on release

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -450,6 +450,51 @@ jobs:
             echo "**Content Hash**: ${CONTENT_HASH}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  notify-downstream:
+    name: Notify api-specs-enriched
+    needs: [check-release-needed, release]
+    # Fire only on a release that actually published. `release` is skipped
+    # whenever `check-release-needed` says there is nothing to publish, and it
+    # fails if `gh release create` fails; `== 'success'` is false in both
+    # cases, so a skipped or failed release never dispatches. This job is
+    # deliberately separate from `release` rather than a step inside it: the
+    # dispatch needs no repository write at all, and keeping it out of the
+    # `contents: write` job keeps that scope on the steps that earn it.
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    # The cross-repo dispatch authenticates with REPO_ADMIN_TOKEN, not
+    # GITHUB_TOKEN (a repository's own GITHUB_TOKEN cannot dispatch to another
+    # repository), so nothing here needs a GITHUB_TOKEN write scope.
+    permissions:
+      contents: read
+
+    steps:
+      # Mirrors the next hop in the chain: api-specs-enriched notifies its own
+      # downstream repos with peter-evans/repository-dispatch and a PAT. The
+      # payload is passed as an action input, never interpolated into a `run:`
+      # body.
+      - name: Dispatch upstream-specs-released to api-specs-enriched
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          repository: f5-sales-demo/api-specs-enriched
+          event-type: upstream-specs-released
+          # yamllint disable-line rule:line-length
+          client-payload: '{"version":"${{ needs.check-release-needed.outputs.version }}","release_tag":"v${{ needs.check-release-needed.outputs.version }}","release_url":"${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.check-release-needed.outputs.version }}","trigger_source":"${{ github.repository }}","run_id":"${{ github.run_id }}"}'
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.check-release-needed.outputs.version }}
+        run: |
+          echo "::notice::Dispatched 'upstream-specs-released' (v${VERSION}) to f5-sales-demo/api-specs-enriched"
+          {
+            echo "### Downstream Notified 📣"
+            echo ""
+            echo "**Event**: \`upstream-specs-released\`"
+            echo "**Target**: \`f5-sales-demo/api-specs-enriched\`"
+            echo "**Version**: v${VERSION}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   skip-release:
     name: Skip Release (No Changes)
     needs: [validate, check-release-needed]
@@ -476,10 +521,13 @@ jobs:
 
   failure-tracker:
     name: Failure Tracker
-    needs: [validate, check-release-needed, release]
+    needs: [validate, check-release-needed, release, notify-downstream]
     # Runs on success too, so the tracker it opens is also the thing that
-    # closes it. `release` is skipped when there is nothing to publish, which
-    # is not a failure.
+    # closes it. `release` and `notify-downstream` are skipped when there is
+    # nothing to publish, which is not a failure. A dispatch that fails after
+    # a successful release is tracked here: it leaves the published correction
+    # unconsumed downstream, which is exactly the silent stall this job exists
+    # to make loud.
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # Opens, updates or closes the single pipeline-failure tracking issue.
@@ -495,6 +543,7 @@ jobs:
           VALIDATE_RESULT: ${{ needs.validate.result }}
           CHECK_RESULT: ${{ needs.check-release-needed.result }}
           RELEASE_RESULT: ${{ needs.release.result }}
+          NOTIFY_RESULT: ${{ needs.notify-downstream.result }}
         with:
           script: |
             // One tracker, not one issue per run. The previous version opened
@@ -547,6 +596,7 @@ jobs:
               `| Validate | ${process.env.VALIDATE_RESULT} |`,
               `| Check Release | ${process.env.CHECK_RESULT} |`,
               `| Release | ${process.env.RELEASE_RESULT} |`,
+              `| Notify Downstream | ${process.env.NOTIFY_RESULT} |`,
               '',
               'The failing step names the cause in its own log; the full',
               'Spectral gate report is in the `validation-reports` artifact.',


### PR DESCRIPTION
Closes #693

## Problem

The spec supply chain was automated at every hop except the first. When this repository published a release, nothing told `api-specs-enriched`: the correction sat unconsumed until the next `0 6 * * *` cron, or until a human ran the enrichment workflow by hand. That happened on 2026-07-24 — after `v2026.07.24-1` published, the enrichment run had to be started with `gh workflow run`.

## Change

A `notify-downstream` job that `repository_dispatch`es `upstream-specs-released` to `f5-sales-demo/api-specs-enriched` with the released version, tag and release URL in `client_payload`.

It **mirrors the next hop in the chain** rather than inventing a mechanism: `api-specs-enriched`'s own `notify-downstream` job uses `peter-evans/repository-dispatch@v3` with a PAT, and passes the payload as an action input. Same action, same shape, same token model — a repository's own `GITHUB_TOKEN` cannot dispatch to another repository, so the cross-repo call authenticates with `REPO_ADMIN_TOKEN`, the PAT this workflow already uses for its other cross-cutting write (`update-docs`).

## It fires only on a real release

`if: needs.release.result == 'success'`. That is false both when `release` is **skipped** (`check-release-needed` found nothing to publish) and when it **fails** (`gh release create` errored) — so a non-release never dispatches. This matters here specifically: the release job has failed silently before (#680), and a trigger that fired on a non-release would reintroduce exactly that class of bug from the other direction.

The job is deliberately separate from `release` rather than a step inside it, so it runs at `contents: read`. The dispatch needs no repository write at all, and keeping it out of the `contents: write` job keeps that scope on the steps that earn it.

`failure-tracker` now also watches `notify-downstream`. A dispatch that fails after a successful release strands the published correction downstream — which is precisely the silent stall that tracker exists to make loud.

## Security

- `client_payload` is built as a `with:` input to the action. Nothing from `github.event.*` reaches a `run:` body; the summary step reads the version from step-level `env:` and quotes it.
- Least privilege: `permissions: contents: read`, the workflow default. No new scope is granted.

## Consumer side

f5-sales-demo/api-specs-enriched#1089 adds `repository_dispatch: types: [upstream-specs-released]` **and** makes that path force-download. Without the second half the trigger would fire and change nothing, because `check-updates` otherwise takes an ETag short-circuit. The daily cron stays on both sides as a safety net.

## Verification

| Check | Result |
| --- | --- |
| `actionlint .github/workflows/*.yml` | exit 0 |
| `yamllint .github/workflows/validate-and-release.yml` | exit 0 |
| `codespell` on the changed file | exit 0 |
| `zizmor --config zizmor.yaml --min-severity medium .github/workflows/` (the audit gate) | `No findings to report` |
| `zizmor` on the changed file | 5 findings, 4 suppressed, **1 low** — byte-identical to `main` |

The one remaining low finding is a pre-existing `adhoc-packages` at `validate-and-release.yml:69` (`npm install -g @stoplight/spectral-cli`, no lockfile), unrelated to this change and unchanged by it — verified by stash-and-compare against `main`. The pre-commit `zizmor` hook has no severity floor and so already fails on `main` for that same finding; `zizmor.yaml` and `.pre-commit-config.yaml` are both governance-managed by docs-control and are not editable here.

End-to-end proof of the chain firing without human action is recorded on #693.