### PR TITLE
fix: harden the downstream dispatch — drop the third-party action and the admin token

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -462,25 +462,47 @@ jobs:
     # `contents: write` job keeps that scope on the steps that earn it.
     if: needs.release.result == 'success'
     runs-on: ubuntu-latest
-    # The cross-repo dispatch authenticates with REPO_ADMIN_TOKEN, not
-    # GITHUB_TOKEN (a repository's own GITHUB_TOKEN cannot dispatch to another
-    # repository), so nothing here needs a GITHUB_TOKEN write scope.
+    # The cross-repo dispatch authenticates with a PAT, not GITHUB_TOKEN (a
+    # repository's own GITHUB_TOKEN cannot dispatch to another repository), so
+    # nothing here needs a GITHUB_TOKEN write scope.
     permissions:
       contents: read
 
     steps:
-      # Mirrors the next hop in the chain: api-specs-enriched notifies its own
-      # downstream repos with peter-evans/repository-dispatch and a PAT. The
-      # payload is passed as an action input, never interpolated into a `run:`
-      # body.
       - name: Dispatch upstream-specs-released to api-specs-enriched
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
-          repository: f5-sales-demo/api-specs-enriched
-          event-type: upstream-specs-released
-          # yamllint disable-line rule:line-length
-          client-payload: '{"version":"${{ needs.check-release-needed.outputs.version }}","release_tag":"v${{ needs.check-release-needed.outputs.version }}","release_url":"${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.check-release-needed.outputs.version }}","trigger_source":"${{ github.repository }}","run_id":"${{ github.run_id }}"}'
+        env:
+          # POST /repos/{owner}/{repo}/dispatches needs Contents: write on the
+          # target and nothing else. REPO_SYNC_TOKEN is the fine-grained fleet
+          # PAT holding Contents R/W, Issues R/W, Pull Requests R/W and
+          # Metadata Read -- the narrowest secret this repository already
+          # carries that can do this. Deliberately NOT REPO_ADMIN_TOKEN, whose
+          # administration rights would turn a leak of this step into a
+          # repository takeover rather than a write. REPO_SETTINGS_TOKEN is not
+          # a candidate either: Administration R/W but Contents *Read* only, so
+          # it is broader in the wrong axis and insufficient in the right one.
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+          VERSION: ${{ needs.check-release-needed.outputs.version }}
+          SOURCE_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # Plain `gh api` rather than a third-party action. A
+          # repository_dispatch is a single API call, so depending on an
+          # external action would hand a privileged token to code sitting
+          # behind a mutable tag -- and `zizmor.yaml` disables `unpinned-uses`,
+          # so nothing here would flag it. `gh` is preinstalled on
+          # GitHub-hosted runners, so this removes a dependency rather than
+          # trading one for another.
+          #
+          # Every value crosses into the shell through env: above and is
+          # referenced as a quoted variable; nothing is interpolated into this
+          # body.
+          gh api "repos/f5-sales-demo/api-specs-enriched/dispatches" \
+            -f "event_type=upstream-specs-released" \
+            -f "client_payload[version]=${VERSION}" \
+            -f "client_payload[release_tag]=v${VERSION}" \
+            -f "client_payload[release_url]=${GITHUB_SERVER_URL}/${SOURCE_REPO}/releases/tag/v${VERSION}" \
+            -f "client_payload[trigger_source]=${SOURCE_REPO}" \
+            -f "client_payload[run_id]=${RUN_ID}"
 
       - name: Summary
         env:


### PR DESCRIPTION
Closes #695

Follow-up to #693 / #694. A security review of the `notify-downstream` job found two issues. Both are fixed here; behaviour is unchanged.

## 1. HIGH — unpinned third-party action holding a privileged token

```diff
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
```

`@v3` is a mutable tag on third-party code, and that code was handed a token with write access to another repository. If the tag were repointed, the next scheduled release run would exfiltrate the token — and nothing in this repository would notice, because `zizmor.yaml` sets `unpinned-uses: disable: true`. A green zizmor run was **not** evidence this was safe.

**Fixed by removing the dependency, not freezing it.** A `repository_dispatch` is a single API call, so the step now uses `gh api`. `gh` is preinstalled on GitHub-hosted runners, so there is no SHA to track, no renovate/dependabot entry to maintain, and no third-party code in the path of a privileged token.

## 2. `REPO_ADMIN_TOKEN` was far more privilege than a dispatch needs

`POST /repos/{owner}/{repo}/dispatches` requires **Contents: write** on the target and nothing else. Administration rights turn a leak of this step from a write into a repository takeover.

Now uses **`REPO_SYNC_TOKEN`** — per docs-control's token model, the fine-grained fleet PAT with *Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read*. Contents R/W is exactly the requirement, and it carries no administration rights.

`REPO_SETTINGS_TOKEN` was considered and rejected: it holds *Administration R/W* but only *Contents Read* — broader in the wrong axis and insufficient in the right one.

### Follow-up, not doable from here

A purpose-scoped `DOWNSTREAM_DISPATCH_TOKEN` — Contents: write on `f5-sales-demo/api-specs-enriched` alone — would be narrower than `REPO_SYNC_TOKEN`, whose write reach spans the fleet. It needs a new PAT plus an entry in docs-control's `secrets_manifest` (`api-specs` currently carries only the `governance` and `claude_review` roles), so it cannot be created from inside this repository. Once it exists, swapping the reference is a one-line change. Recorded on #695.

## Unchanged guarantees

- Dispatches only on a release that actually published (`needs.release.result == 'success'`, false when `release` is skipped **or** failed).
- `permissions: contents: read`.
- Every payload value crosses into the shell through step-level `env:` and is referenced as a quoted variable. Nothing from `github.event.*` or any secret is interpolated into the `run:` body.

## Verification

The `gh api` nested-parameter form was verified **live** against the target before being committed — both `-F` and `-f` are accepted, and the dispatch started a real run with `event_name == repository_dispatch`. `-f` is used here so every payload field stays a string, avoiding `-F`'s magic type coercion and its `@filename` behaviour.

| Check | Result |
| --- | --- |
| `actionlint .github/workflows/*.yml` | exit 0 |
| `yamllint` on the changed file | exit 0 |
| `codespell` on the changed file | exit 0 |
| `zizmor --config zizmor.yaml --min-severity medium .github/workflows/` | `No findings to report`, exit 0 |

And the finding itself, proven gone rather than assumed — with zizmor's `unpinned-uses` force-enabled via `--no-config`:

```
# origin/main
error[unpinned-uses]: unpinned action reference
   --> .github/workflows/validate-and-release.yml:477:15
477 |         uses: peter-evans/repository-dispatch@v3
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash

# this branch
findings mentioning peter-evans: 0
```

The remaining low finding on this file is the pre-existing `adhoc-packages` at line 69 (`npm install -g @stoplight/spectral-cli`, no lockfile), unrelated and unchanged.

## Scope note

The equivalent pre-existing instance in `api-specs-enriched/.github/workflows/sync-and-enrich.yml:859` is **left untouched** — tracked separately rather than widening this PR.