### PR TITLE
fix(transform): wrap the $ref before annotating it, unblocking releases

### DIFF
--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -221,6 +221,30 @@ def _preserves_wire_key(rule: dict) -> bool:
     return not (rule.get("verified", False) and rule.get("api_status") == FIX_SPEC_STATUS)
 
 
+def _annotate_wire_name(prop: dict, wire_name: str) -> None:
+    """Record *wire_name* on *prop* without ever giving a ``$ref`` a sibling.
+
+    A ``$ref`` *replaces* the object holding it, so OpenAPI 3.0 forbids keys
+    beside one: resolvers discard them and Spectral reports
+    ``no-$ref-siblings``, an error the release gate caps at zero.  A property
+    that is a ``$ref`` is therefore moved inside ``allOf`` first -- the OAS3
+    way to carry keywords alongside a reference -- and the annotation becomes
+    a sibling of the wrapper instead.
+
+    The wrap is applied only when a ``$ref`` is present.  A plain object
+    property (the common case) is annotated in place, because wrapping one
+    that needs no wrapper would rewrite the shape of the whole artifact for
+    nothing.  A property that already composes with ``allOf`` gains the
+    annotation beside that ``allOf`` rather than a second nested one.
+    """
+    if "$ref" in prop:
+        wrapped = {"$ref": prop.pop("$ref")}
+        composed = prop.get("allOf")
+        prop["allOf"] = [wrapped, *composed] if isinstance(composed, list) else [wrapped]
+
+    prop[WIRE_NAME_EXTENSION] = wire_name
+
+
 def _rename_key_in_place(mapping: dict, old_key: str, new_key: str) -> dict:
     """Return a copy of *mapping* with *old_key* renamed, keeping its position."""
     return {(new_key if key == old_key else key): value for key, value in mapping.items()}
@@ -236,8 +260,10 @@ def _rename_schema_property(
 
     Covers the ``properties`` key itself, any mention in ``required``, and any
     ``x-ves-oneof-field-*`` group that lists the property by name.  When
-    *wire_name* is given it is recorded on the renamed property so downstream
-    consumers can present the corrected name while marshalling the original.
+    *wire_name* is given it is recorded on the renamed property by
+    :func:`_annotate_wire_name`, so downstream consumers can present the
+    corrected name while marshalling the original and the result stays legal
+    OpenAPI 3.0.
 
     Returns ``True`` when the schema declared *old_key* and was rewritten.  A
     schema that already declares *new_key* is left alone: the two keys are
@@ -255,7 +281,7 @@ def _rename_schema_property(
             if prop.get(label_key) == old_key:
                 prop[label_key] = new_key
         if wire_name is not None:
-            prop[WIRE_NAME_EXTENSION] = wire_name
+            _annotate_wire_name(prop, wire_name)
 
     required = schema_def.get("required")
     if isinstance(required, list):

--- a/tests/test_property_name_corrections.py
+++ b/tests/test_property_name_corrections.py
@@ -111,6 +111,41 @@ def _corrected_schemas(new_key: str, specs: list[tuple[str, dict, dict]]) -> lis
     ]
 
 
+def _annotated_objects(obj: Any, path: str = "") -> list[tuple[str, dict]]:
+    """Return ``(dotted path, object)`` for every object carrying the annotation.
+
+    Walks the whole document, not just ``components.schemas``: a guard that
+    only looked where the transform writes today would stop holding the moment
+    it writes somewhere else.
+    """
+    found: list[tuple[str, dict]] = []
+    if isinstance(obj, dict):
+        if WIRE_NAME_EXTENSION in obj:
+            found.append((path, obj))
+        for key, value in obj.items():
+            found.extend(_annotated_objects(value, f"{path}.{key}" if path else key))
+    elif isinstance(obj, list):
+        for index, item in enumerate(obj):
+            found.extend(_annotated_objects(item, f"{path}.{index}"))
+    return found
+
+
+def _ref_values(obj: Any, path: str = "") -> list[tuple[str, str]]:
+    """Return ``(dotted path, target)`` for every ``$ref`` reachable in *obj*."""
+    found: list[tuple[str, str]] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            child = f"{path}.{key}" if path else key
+            if key == "$ref" and isinstance(value, str):
+                found.append((child, value))
+            else:
+                found.extend(_ref_values(value, child))
+    elif isinstance(obj, list):
+        for index, item in enumerate(obj):
+            found.extend(_ref_values(item, f"{path}.{index}"))
+    return found
+
+
 def _string_values(obj: Any) -> list[str]:
     """Collect every string value reachable in *obj*."""
     if isinstance(obj, dict):
@@ -220,6 +255,60 @@ class TestReleasedSpecsAreCorrected:
                         assert f'"{old_key}"' not in value, (
                             f"{name}/{schema_name}/{key} still names {old_key}"
                         )
+
+
+class TestAnnotationIsLegalOAS3:
+    """The annotation must never make the artifact illegal OpenAPI 3.0.
+
+    A ``$ref`` *replaces* the object holding it, so OAS3 forbids siblings:
+    every resolver discards them and Spectral reports ``no-$ref-siblings`` as
+    an **error**, which the release gate caps at zero.  Annotating a property
+    that is a ``$ref`` therefore has to wrap it in ``allOf`` rather than sit
+    beside it.  Without this guard the first ``$ref``-shaped correction blocks
+    every release for every consumer -- which is exactly what happened (#698).
+
+    Data-driven over the real config and the real specs, so a correction added
+    later is covered the day it lands.
+    """
+
+    def test_no_wire_annotation_is_a_ref_sibling(self, transformed_specs):
+        """The guard: not one annotation anywhere may share an object with ``$ref``."""
+        offenders = [
+            f"{name}: {path or '<root>'}"
+            for name, _original, transformed in transformed_specs
+            for path, obj in _annotated_objects(transformed)
+            if "$ref" in obj
+        ]
+        assert not offenders, (
+            f"{len(offenders)} {WIRE_NAME_EXTENSION} annotation(s) sit next to a $ref, "
+            "which Spectral rejects as no-$ref-siblings and the release gate "
+            f"caps at zero errors: {offenders}"
+        )
+
+    def test_the_guard_is_not_vacuous(self, transformed_specs):
+        """A guard that never sees an annotation cannot catch a bad one."""
+        annotated = [
+            path
+            for _n, _o, transformed in transformed_specs
+            for path, _ in _annotated_objects(transformed)
+        ]
+        assert annotated, "the transform emitted no annotation at all"
+
+    def test_a_wrapped_property_still_references_the_same_schema(self, transformed_specs):
+        """Wrapping may move the ``$ref``; it may never change its target."""
+        renames = {c["old_key"]: c["new_key"] for c in CORRECTIONS}
+        for name, original, transformed in transformed_specs:
+            after = _schemas(transformed)
+            for schema_name, schema in _schemas(original).items():
+                for prop_name, prop in schema.get("properties", {}).items():
+                    if not isinstance(prop, dict) or "$ref" not in prop:
+                        continue
+                    corrected = renames.get(prop_name, prop_name)
+                    now = after[schema_name]["properties"][corrected]
+                    refs = sorted(ref for _p, ref in _ref_values(now))
+                    assert refs == [prop["$ref"]], (
+                        f"{name}/{schema_name}/{prop_name}: $ref target changed"
+                    )
 
 
 class TestNothingElseMoves:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 
 import pytest
@@ -836,3 +837,83 @@ class TestFixPropertyNames:
         props = result["components"]["schemas"]["WidgetSpec"]["properties"]
         assert props[FIXED_KEY][WIRE_NAME_EXTENSION] == TYPO_KEY
         assert WIRE_NAME_EXTENSION not in props[OTHER_FIXED_KEY]
+
+
+class TestWireNameAnnotationShape:
+    """Where the annotation lands, so the artifact stays legal OpenAPI 3.0.
+
+    A ``$ref`` replaces the object holding it, so OAS3 forbids siblings and
+    Spectral reports ``no-$ref-siblings`` -- an error the release gate caps at
+    zero.  The annotation therefore has to wrap a ``$ref`` property in
+    ``allOf`` instead of sitting beside it, and has to leave every other shape
+    alone (#698).
+    """
+
+    def test_ref_property_is_wrapped_rather_than_given_a_sibling(self):
+        """OAS3 forbids ``$ref`` siblings, so the reference moves into ``allOf``."""
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY] = {
+            "$ref": "#/components/schemas/ioschemaEmpty"
+        }
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert "$ref" not in prop
+        assert prop["allOf"] == [{"$ref": "#/components/schemas/ioschemaEmpty"}]
+        assert prop[WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    def test_ref_property_is_left_bare_when_no_wire_name_is_recorded(self):
+        """A verified ``fix_spec`` adds nothing, so there is nothing to wrap."""
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY] = {
+            "$ref": "#/components/schemas/ioschemaEmpty"
+        }
+        result = fix_property_names(spec, _corrections_config(_fix_spec_rule()), "test.json")
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert prop == {"$ref": "#/components/schemas/ioschemaEmpty"}
+
+    def test_plain_object_property_is_annotated_without_an_allof_wrapper(self):
+        """Wrapping a property that needs no wrapper would churn the artifact."""
+        result = fix_property_names(
+            _widget_spec(), _corrections_config(_wire_preserving_rule()), "test.json"
+        )
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert "allOf" not in prop
+        assert prop["type"] == "string"
+
+    def test_existing_allof_gains_the_annotation_beside_it(self):
+        """An ``allOf`` already there is composition, not a wrapper to nest in."""
+        composed = {"allOf": [{"$ref": "#/components/schemas/Base"}], "description": "d"}
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY] = copy.deepcopy(
+            composed
+        )
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert prop["allOf"] == composed["allOf"]
+        assert prop[WIRE_NAME_EXTENSION] == TYPO_KEY
+
+    def test_ref_with_siblings_keeps_them_beside_the_wrapper(self):
+        """Keywords already beside the ``$ref`` survive, legally, next to ``allOf``."""
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY] = {
+            "$ref": "#/components/schemas/Base",
+            "description": "d",
+        }
+        result = fix_property_names(spec, _corrections_config(_wire_preserving_rule()), "test.json")
+        prop = result["components"]["schemas"]["WidgetSpec"]["properties"][FIXED_KEY]
+        assert prop == {
+            "description": "d",
+            "allOf": [{"$ref": "#/components/schemas/Base"}],
+            WIRE_NAME_EXTENSION: TYPO_KEY,
+        }
+
+    def test_wrapping_a_ref_property_is_idempotent(self):
+        """A second pass must not nest the wrapper inside another wrapper."""
+        spec = _widget_spec()
+        spec["components"]["schemas"]["WidgetSpec"]["properties"][TYPO_KEY] = {
+            "$ref": "#/components/schemas/ioschemaEmpty"
+        }
+        config = _corrections_config(_wire_preserving_rule())
+        once = fix_property_names(spec, config, "test.json")
+        twice = fix_property_names(copy.deepcopy(once), config, "test.json")
+        assert twice == once


### PR DESCRIPTION
Closes #698

## What was broken

#689 recorded F5's wire key on each renamed property as `x-f5xc-wire-name`, and
wrote it straight onto the property object. Eleven of the renamed properties are
a bare `$ref`, so the annotation landed as a **`$ref` sibling** — which OpenAPI
3.0 forbids, because a `$ref` *replaces* the object holding it. Spectral reports
that as `no-$ref-siblings`, the release gate caps errors at zero, and `api-specs`
has published nothing since. It re-broke the pipeline #687 had just repaired
after a 13-day outage, and it is the reason #693's end-to-end verification could
not run (`notify-downstream` correctly skips when no release publishes).

The annotation was not only illegal, it was **unreliable**: a strict resolver
discards `$ref` siblings, so the wire key could have been dropped on the floor by
exactly the consumers that need it.

## The fix

`_annotate_wire_name` moves a `$ref` inside `allOf` before recording the key —
the OAS3 way to carry keywords alongside a reference:

```json
{"$ref": "#/components/schemas/ioschemaEmpty"}
```
becomes
```json
{"allOf": [{"$ref": "#/components/schemas/ioschemaEmpty"}],
 "x-f5xc-wire-name": "disable_lb_source_ip_persistance"}
```

**Wrap only when needed — the rule is `"$ref" in prop`.** A `$ref` present at
all is exactly the condition under which adding a key creates an illegal
sibling; absent, there is nothing to make legal. So:

| Property shape | Result | Count |
| --- | --- | --- |
| bare `{"$ref": …}` | wrapped in `allOf`, annotation beside the wrapper | 11 |
| plain object (`type`, `items`, …) | annotated **in place**, no wrapper | 16 |
| `$ref` **plus** other keys | wrapped; the existing keys stay legally beside `allOf` | 0 today |
| already has `allOf` | annotation added **beside** that `allOf`, never nested inside a second one | 0 today |

The last two do not occur in today's specs but are pinned by unit tests, because
the shape upstream ships is not ours to choose. Plain objects are deliberately
left alone: wrapping one that needs no wrapper would rewrite the shape of the
whole artifact for nothing.

## The guard — the actual defect

#689 shipped 269 acceptance tests, and not one asserted *where* the annotation
lands, only that it holds the right value. A correction whose property happened
to be a `$ref` was outside every assertion, so the first one blocked every
release.

`TestAnnotationIsLegalOAS3` (`tests/test_property_name_corrections.py`) walks the
**whole** transform output — not just `components.schemas` — over the real
`config/property_name_corrections.yaml` × the real `release/specs`, and fails if
any object carrying `x-f5xc-wire-name` also carries `$ref`. A correction added
later is covered the day it lands, whatever shape upstream gives it. Two
companions keep it honest: one asserts wrapping never changes a `$ref` target,
one refuses to let the guard pass vacuously.

Red → green, with the final test code:

```
### RED (scripts/transform.py at main) ###
FAILED …TestAnnotationIsLegalOAS3::test_no_wire_annotation_is_a_ref_sibling
  AssertionError: 11 x-f5xc-wire-name annotation(s) sit next to a $ref …
FAILED …TestWireNameAnnotationShape::test_ref_property_is_wrapped_rather_than_given_a_sibling
FAILED …TestWireNameAnnotationShape::test_ref_with_siblings_keeps_them_beside_the_wrapper
3 failed, 6 passed

### GREEN (fix applied) ###
9 passed
```

The 11 offenders the guard names are precisely the 11 Spectral errors.

## Verification

**Spectral gate — the thing that is red today**

```
before:  Gate check: 11 errors, 4 warnings   Gate FAILED: 11 errors exceeds max 0   (exit 1)
after:   Gate check:  0 errors, 4 warnings   Gate PASSED                            (exit 0)
```

**Wire keys — not one byte moves**

- 27 annotations emitted, **0** of them a `$ref` sibling (was 11)
- 11 `allOf`-wrapped, 16 annotated in place
- every `old_key` absent from the output; every `new_key` present
- wire keys unchanged: `blocked_sevice` × 7, `public_advertisment` × 8,
  `disable_/enable_lb_source_ip_persistance` × 3 each,
  `volterra_software_overide` × 2, `previous_reqeust_count` × 2,
  `public_advertisment_enabled` × 1, `OBSOLOTE_upperBound` × 1

**Tests** — `250 passed, 1 skipped`. Canaries re-run explicitly:
`tests/test_dangling_refs.py` (14, #687),
`test_release_specs_contain_no_configured_typos` +
`test_corrections_never_match_an_identifier` (#679),
`test_no_wire_key_changes_anywhere`, and all 9 per-entry
`test_wire_key_is_preserved[…]`.

**Cross-repo compatibility — verified, not assumed**

terraform-provider-xcsh already consumes this annotation (#1324, merged as
`5f65665a`). Both shapes were fed through its real codegen from JSON, read-only,
in a throwaway module that `replace`s the provider path — the provider working
tree was never modified:

```
before(($ref sibling)) = {… TfsdkTag:disable_lb_source_ip_persistence … JsonName:disable_lb_source_ip_persistance … NestedBlockType:single IsBlock:true …}
after (allOf-wrapped)  = {… TfsdkTag:disable_lb_source_ip_persistence … JsonName:disable_lb_source_ip_persistance … NestedBlockType:single IsBlock:true …}
```

Byte-identical `TerraformAttribute`, `JsonName` included.
`ConvertToTerraformAttributeWithDepth` reads `schema.WireName(name)` *before*
resolving `$ref` and already unwraps single-element `allOf`. A non-`Empty`
target (`siteSiteSoftwareOverrideType`) still resolves to its nested attributes.
The provider's own `TestWireNameDrivesJSONNameOnly` also covers the
`allOf`-wrapped case and passes.

**Lint** — `ruff check` clean, `mypy` clean, all three changed files pass
`ruff format --check` (`line-length` unchanged at 100). Stash-and-compare against
untouched `main` shows the branch adds **zero** new `ruff format` failures (16
pre-existing, tracked as #691) and **no new pylint message class** — the one
genuinely new finding, `R0904 too-many-public-methods`, was fixed at the source
by moving the shape tests into their own `TestWireNameAnnotationShape` class
rather than suppressed. `pre-commit --all-files` output is byte-identical to
untouched `main` (`SKIP=zizmor`; zizmor exits 1 on untouched `main` too, from the
pre-existing `adhoc-packages` finding on `validate-and-release.yml`).

`release/specs` is deliberately not regenerated here, as in #689 — the daily
pipeline regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
