### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,8 +1,8 @@
 {
   "spec_date": "2026.07.24",
   "spec_timestamp": "2026-07-24T17:30:26+00:00",
-  "download_date": "2026.07.25",
-  "download_timestamp": "2026-07-25T14:46:19.866322+00:00",
+  "download_date": "2026.07.27",
+  "download_timestamp": "2026-07-27T16:21:38.694716+00:00",
   "etag": "W/\"33e92e-19f952dab50\"",
   "last_modified": "Fri, 24 Jul 2026 17:30:26 GMT",
   "file_count": 283,

--- a/release/specs/docs-cloud-f5-com.0072.public.ves.io.schema.views.voltstack_site.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0072.public.ves.io.schema.views.voltstack_site.ves-swagger.json
@@ -1453,6 +1453,20 @@
           "api_token": {
             "$ref": "#/components/schemas/schemaSecretType"
           },
+          "labels": {
+            "type": "object",
+            "description": " The labels are optional, and can be any key-value pair for use with the PSO \"fleet\" provisioner.\n\nExample: ` \"{\"rack\"\"22\"}\"`\n\nValidation Rules:\n  ves.io.schema.rules.map.keys.string.max_len: 128\n  ves.io.schema.rules.map.keys.string.min_len: 1\n  ves.io.schema.rules.map.max_pairs: 20\n  ves.io.schema.rules.map.values.string.max_len: 128\n  ves.io.schema.rules.map.values.string.min_len: 1\n",
+            "title": "Labels",
+            "x-displayname": "Labels",
+            "x-ves-example": "{\"rack\": \"22\"}",
+            "x-ves-validation-rules": {
+              "ves.io.schema.rules.map.keys.string.max_len": "128",
+              "ves.io.schema.rules.map.keys.string.min_len": "1",
+              "ves.io.schema.rules.map.max_pairs": "20",
+              "ves.io.schema.rules.map.values.string.max_len": "128",
+              "ves.io.schema.rules.map.values.string.min_len": "1"
+            }
+          },
           "mgmt_dns_name": {
             "type": "string",
             "description": "Exclusive with [mgmt_ip]\n Management Endpoint's ip address is discovered using DNS name resolution. The name given here is fully qualified domain name.\n\nExample: ` \"storage.local\"`\n\nValidation Rules:\n  ves.io.schema.rules.string.hostname: true\n  ves.io.schema.rules.string.max_len: 256\n",
@@ -1495,20 +1509,6 @@
             "x-ves-example": "10.5.2.4",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.ip": "true"
-            }
-          },
-          "labels": {
-            "type": "object",
-            "description": " The labels are optional, and can be any key-value pair for use with the PSO \"fleet\" provisioner.\n\nExample: ` \"{\"rack\"\"22\"}\"`\n\nValidation Rules:\n  ves.io.schema.rules.map.keys.string.max_len: 128\n  ves.io.schema.rules.map.keys.string.min_len: 1\n  ves.io.schema.rules.map.max_pairs: 20\n  ves.io.schema.rules.map.values.string.max_len: 128\n  ves.io.schema.rules.map.values.string.min_len: 1\n",
-            "title": "Labels",
-            "x-displayname": "Labels",
-            "x-ves-example": "{\"rack\": \"22\"}",
-            "x-ves-validation-rules": {
-              "ves.io.schema.rules.map.keys.string.max_len": "128",
-              "ves.io.schema.rules.map.keys.string.min_len": "1",
-              "ves.io.schema.rules.map.max_pairs": "20",
-              "ves.io.schema.rules.map.values.string.max_len": "128",
-              "ves.io.schema.rules.map.values.string.min_len": "1"
             }
           }
         }

--- a/release/specs/docs-cloud-f5-com.0124.public.ves.io.schema.fleet.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0124.public.ves.io.schema.fleet.ves-swagger.json
@@ -1204,6 +1204,20 @@
           "api_token": {
             "$ref": "#/components/schemas/schemaSecretType"
           },
+          "labels": {
+            "type": "object",
+            "description": " The labels are optional, and can be any key-value pair for use with the PSO \"fleet\" provisioner.\n\nExample: ` \"{\"rack\"\"22\"}\"`\n\nValidation Rules:\n  ves.io.schema.rules.map.keys.string.max_len: 128\n  ves.io.schema.rules.map.keys.string.min_len: 1\n  ves.io.schema.rules.map.max_pairs: 20\n  ves.io.schema.rules.map.values.string.max_len: 128\n  ves.io.schema.rules.map.values.string.min_len: 1\n",
+            "title": "Labels",
+            "x-displayname": "Labels",
+            "x-ves-example": "{\"rack\": \"22\"}",
+            "x-ves-validation-rules": {
+              "ves.io.schema.rules.map.keys.string.max_len": "128",
+              "ves.io.schema.rules.map.keys.string.min_len": "1",
+              "ves.io.schema.rules.map.max_pairs": "20",
+              "ves.io.schema.rules.map.values.string.max_len": "128",
+              "ves.io.schema.rules.map.values.string.min_len": "1"
+            }
+          },
           "mgmt_dns_name": {
             "type": "string",
             "description": "Exclusive with [mgmt_ip]\n Management Endpoint's ip address is discovered using DNS name resolution. The name given here is fully qualified domain name.\n\nExample: ` \"storage.local\"`\n\nValidation Rules:\n  ves.io.schema.rules.string.hostname: true\n  ves.io.schema.rules.string.max_len: 256\n",
@@ -1246,20 +1260,6 @@
             "x-ves-example": "10.5.2.4",
             "x-ves-validation-rules": {
               "ves.io.schema.rules.string.ip": "true"
-            }
-          },
-          "labels": {
-            "type": "object",
-            "description": " The labels are optional, and can be any key-value pair for use with the PSO \"fleet\" provisioner.\n\nExample: ` \"{\"rack\"\"22\"}\"`\n\nValidation Rules:\n  ves.io.schema.rules.map.keys.string.max_len: 128\n  ves.io.schema.rules.map.keys.string.min_len: 1\n  ves.io.schema.rules.map.max_pairs: 20\n  ves.io.schema.rules.map.values.string.max_len: 128\n  ves.io.schema.rules.map.values.string.min_len: 1\n",
-            "title": "Labels",
-            "x-displayname": "Labels",
-            "x-ves-example": "{\"rack\": \"22\"}",
-            "x-ves-validation-rules": {
-              "ves.io.schema.rules.map.keys.string.max_len": "128",
-              "ves.io.schema.rules.map.keys.string.min_len": "1",
-              "ves.io.schema.rules.map.max_pairs": "20",
-              "ves.io.schema.rules.map.values.string.max_len": "128",
-              "ves.io.schema.rules.map.values.string.min_len": "1"
             }
           }
         }


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.