### PR TITLE
style: reformat to the configured line-length of 100

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -144,14 +144,10 @@ def download_specs(
 
         # Not modified - use cached version
         if response.status_code == HTTP_NOT_MODIFIED:
-            console.print(
-                "[green]Specs unchanged (ETag match), using cached version[/green]"
-            )
+            console.print("[green]Specs unchanged (ETag match), using cached version[/green]")
             # Return existing files
             cached_files = [
-                str(f.relative_to(output_dir))
-                for f in output_dir.glob("**/*")
-                if f.is_file()
+                str(f.relative_to(output_dir)) for f in output_dir.glob("**/*") if f.is_file()
             ]
             return False, cached_files
 
@@ -189,9 +185,7 @@ def download_specs(
         # Save metadata for versioning (includes upstream Last-Modified date)
         save_metadata(output_dir, new_etag, last_modified, len(extracted_files))
 
-        console.print(
-            f"[green]Extracted {len(extracted_files)} files to {output_dir}[/green]"
-        )
+        console.print(f"[green]Extracted {len(extracted_files)} files to {output_dir}[/green]")
 
     except requests.exceptions.RequestException as e:
         console.print(f"[red]Download failed: {e}[/red]")
@@ -254,9 +248,7 @@ def compute_checksum(filepath: Path) -> str:
 
 def main() -> int:
     """Main entry point for download command."""
-    parser = argparse.ArgumentParser(
-        description="Download F5 XC OpenAPI specifications"
-    )
+    parser = argparse.ArgumentParser(description="Download F5 XC OpenAPI specifications")
     parser.add_argument(
         "--config",
         type=Path,
@@ -289,9 +281,7 @@ def main() -> int:
 
     # Determine paths
     url = download_config.get("url", DEFAULT_DOWNLOAD_URL)
-    output_dir = args.output_dir or Path(
-        download_config.get("output_dir", DEFAULT_OUTPUT_DIR)
-    )
+    output_dir = args.output_dir or Path(download_config.get("output_dir", DEFAULT_OUTPUT_DIR))
     etag_cache = Path(download_config.get("etag_cache", DEFAULT_ETAG_CACHE))
 
     # Download specs

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -23,9 +23,7 @@ description: F5 XC API spec validation and fix report
 def load_json_report(report_path: Path, report_type: str = "report") -> dict | None:
     """Load a JSON report file."""
     if not report_path.exists():
-        console.print(
-            f"[yellow]{report_type.capitalize()} not found: {report_path}[/yellow]"
-        )
+        console.print(f"[yellow]{report_type.capitalize()} not found: {report_path}[/yellow]")
         return None
 
     try:
@@ -291,9 +289,7 @@ def _generate_discrepancies_section(report: dict) -> list[str]:
             api_str = _format_value(api_val)
             dtype_badge = _get_type_badge(dtype)
 
-            lines.append(
-                f"| `{prop}` | `{constraint}` | {dtype_badge} | {spec_str} | {api_str} |"
-            )
+            lines.append(f"| `{prop}` | `{constraint}` | {dtype_badge} | {spec_str} | {api_str} |")
 
         lines.append("")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -177,9 +177,7 @@ def get_version_from_metadata(specs_dir: Path, patch: int | None = None) -> str:
             console.print(f"[dim]Using upstream spec date: {base_date}[/dim]")
         else:
             base_date = datetime.now(UTC).strftime("%Y.%m.%d")
-            console.print(
-                "[yellow]No spec date in metadata, using current date[/yellow]"
-            )
+            console.print("[yellow]No spec date in metadata, using current date[/yellow]")
     else:
         # Fallback to current date if no metadata
         base_date = datetime.now(UTC).strftime("%Y.%m.%d")
@@ -359,9 +357,7 @@ class ReleaseBuilder:
         with (staging_dir / "openapi.yaml").open("w") as f:
             yaml.safe_dump(merged, f, default_flow_style=False, sort_keys=False)
 
-        console.print(
-            f"  [dim]Created: openapi.json ({len(merged['paths'])} paths)[/dim]"
-        )
+        console.print(f"  [dim]Created: openapi.json ({len(merged['paths'])} paths)[/dim]")
         console.print("  [dim]Created: openapi.yaml[/dim]")
 
     def _copy_changelog(self, staging_dir: Path) -> None:
@@ -414,9 +410,7 @@ Release date: {datetime.now(UTC).strftime("%Y-%m-%d")}
                 issue_mapping if issue_mapping.exists() else None,
             )
             (staging_dir / "VALIDATION_REPORT.md").write_text(report_content)
-            console.print(
-                "  [dim]Generated: VALIDATION_REPORT.md (with issue tracking)[/dim]"
-            )
+            console.print("  [dim]Generated: VALIDATION_REPORT.md (with issue tracking)[/dim]")
             return
 
         if validation_md.exists():
@@ -518,9 +512,7 @@ See full validation details in the repository.
 
 def main() -> int:
     """Main entry point for release command."""
-    parser = argparse.ArgumentParser(
-        description="Build release package for F5 XC fixed specs"
-    )
+    parser = argparse.ArgumentParser(description="Build release package for F5 XC fixed specs")
     parser.add_argument(
         "--config",
         type=Path,

--- a/scripts/utils/auth.py
+++ b/scripts/utils/auth.py
@@ -61,10 +61,7 @@ class RateLimiter:
             now = time.time()
 
             # Clean old entries (older than 60 seconds)
-            while (
-                self._request_times
-                and now - self._request_times[0] > RATE_LIMIT_WINDOW_SECONDS
-            ):
+            while self._request_times and now - self._request_times[0] > RATE_LIMIT_WINDOW_SECONDS:
                 self._request_times.popleft()
 
             # Check requests per minute
@@ -72,9 +69,7 @@ class RateLimiter:
                 oldest = self._request_times[0]
                 wait_time = RATE_LIMIT_WINDOW_SECONDS - (now - oldest) + 0.1
                 if wait_time > 0:
-                    console.print(
-                        f"[yellow]Rate limit: waiting {wait_time:.1f}s[/yellow]"
-                    )
+                    console.print(f"[yellow]Rate limit: waiting {wait_time:.1f}s[/yellow]")
                     time.sleep(wait_time)
                     now = time.time()
 
@@ -104,9 +99,7 @@ class RateLimiter:
                 )
                 if new_rpm > self._current_rpm:
                     self._current_rpm = new_rpm
-                    console.print(
-                        f"[green]Rate limit increased to {self._current_rpm} RPM[/green]"
-                    )
+                    console.print(f"[green]Rate limit increased to {self._current_rpm} RPM[/green]")
                 self._success_streak = 0
 
     def record_rate_limit(self) -> float:
@@ -120,9 +113,7 @@ class RateLimiter:
                     MIN_RPM,
                     int(self._current_rpm * self.config.decrease_factor),
                 )
-                console.print(
-                    f"[red]Rate limit hit, reduced to {self._current_rpm} RPM[/red]"
-                )
+                console.print(f"[red]Rate limit hit, reduced to {self._current_rpm} RPM[/red]")
 
             # Calculate backoff
             backoff = self._current_backoff
@@ -154,12 +145,8 @@ class F5XCAuth:
         )
     )
     api_token: str = field(default_factory=lambda: os.getenv("F5XC_API_TOKEN", ""))
-    namespace: str = field(
-        default_factory=lambda: os.getenv("F5XC_NAMESPACE", "example-namespace")
-    )
-    tenant: str = field(
-        default_factory=lambda: os.getenv("F5XC_TENANT", "example-tenant")
-    )
+    namespace: str = field(default_factory=lambda: os.getenv("F5XC_NAMESPACE", "example-namespace"))
+    tenant: str = field(default_factory=lambda: os.getenv("F5XC_TENANT", "example-tenant"))
     timeout: int = 30
     retries: int = 3
 
@@ -238,9 +225,7 @@ class F5XCAuth:
 
             except httpx.TimeoutException as e:
                 last_exception = e
-                console.print(
-                    f"[yellow]Timeout on attempt {attempt + 1}/{self.retries}[/yellow]"
-                )
+                console.print(f"[yellow]Timeout on attempt {attempt + 1}/{self.retries}[/yellow]")
                 time.sleep(self._rate_limiter.config.initial_backoff * (attempt + 1))
 
             except httpx.RequestError as e:

--- a/scripts/utils/constraint_validator.py
+++ b/scripts/utils/constraint_validator.py
@@ -24,12 +24,8 @@ class DiscrepancyType(Enum):
     EXTRA_CONSTRAINT = "extra_constraint"  # Spec has constraint API ignores
     CONSTRAINT_MISMATCH = "constraint_mismatch"  # Different constraint values
     TYPE_MISMATCH = "type_mismatch"  # Different data types
-    SPECTRAL_MISSING = (
-        "spectral_missing"  # Required OAS element absent (tags, servers, contact)
-    )
-    SPECTRAL_INVALID = (
-        "spectral_invalid"  # Element present but invalid (bad example, script tag)
-    )
+    SPECTRAL_MISSING = "spectral_missing"  # Required OAS element absent (tags, servers, contact)
+    SPECTRAL_INVALID = "spectral_invalid"  # Element present but invalid (bad example, script tag)
     SPECTRAL_UNUSED = "spectral_unused"  # Dead code (unused component schema)
 
 
@@ -100,9 +96,7 @@ class ConstraintValidator:
         """Generate test cases for a specific constraint."""
         generator = self._test_generators.get(constraint_type)
         if generator:
-            result: list[ValidationTestCase] = generator(
-                constraint_value, property_schema or {}
-            )
+            result: list[ValidationTestCase] = generator(constraint_value, property_schema or {})
             return result
         return []
 

--- a/scripts/utils/github_issues.py
+++ b/scripts/utils/github_issues.py
@@ -80,9 +80,7 @@ class GitHubIssues:
         )
         r.raise_for_status()
 
-    def search_by_label(
-        self, label: str, *, state: str = "open"
-    ) -> list[dict[str, Any]]:
+    def search_by_label(self, label: str, *, state: str = "open") -> list[dict[str, Any]]:
         """Return the list of issues carrying ``label`` in the given ``state``."""
         r = self._client.get(
             f"/repos/{self._repo}/issues",

--- a/scripts/utils/report_generator.py
+++ b/scripts/utils/report_generator.py
@@ -74,9 +74,7 @@ class ReportGenerator:
         methods = self._align_parallel_list(discrepancy_methods, len(discrepancies))
 
         # Create summary
-        summary = self._create_summary(
-            results, discrepancies, modified_files, unmodified_files
-        )
+        summary = self._create_summary(results, discrepancies, modified_files, unmodified_files)
 
         output_files = {}
 
@@ -86,13 +84,9 @@ class ReportGenerator:
                     summary, results, discrepancies, domains, methods
                 )
             elif fmt == "html":
-                output_files["html"] = self._generate_html(
-                    summary, results, discrepancies
-                )
+                output_files["html"] = self._generate_html(summary, results, discrepancies)
             elif fmt == "markdown":
-                output_files["markdown"] = self._generate_markdown(
-                    summary, results, discrepancies
-                )
+                output_files["markdown"] = self._generate_markdown(summary, results, discrepancies)
 
         return output_files
 
@@ -173,9 +167,7 @@ class ReportGenerator:
         """Generate HTML report."""
         output_path = self.config.output_dir / "validation_report.html"
 
-        template = Environment(loader=BaseLoader(), autoescape=True).from_string(
-            HTML_TEMPLATE
-        )
+        template = Environment(loader=BaseLoader(), autoescape=True).from_string(HTML_TEMPLATE)
 
         html = template.render(
             summary=summary,
@@ -219,8 +211,7 @@ class ReportGenerator:
         ]
 
         lines.extend(
-            f"- {dtype}: {count}"
-            for dtype, count in summary.discrepancies_by_type.items()
+            f"- {dtype}: {count}" for dtype, count in summary.discrepancies_by_type.items()
         )
 
         lines.extend(
@@ -334,9 +325,7 @@ class ReportGenerator:
             "discrepancy_type": discrepancy.discrepancy_type.value,
             "spec_value": discrepancy.spec_value,
             "api_behavior": discrepancy.api_behavior,
-            "test_values": discrepancy.test_values[
-                : self.config.max_examples_per_issue
-            ],
+            "test_values": discrepancy.test_values[: self.config.max_examples_per_issue],
             "recommendation": discrepancy.recommendation,
             "domain": domain,
             "method": method,

--- a/scripts/utils/schemathesis_runner.py
+++ b/scripts/utils/schemathesis_runner.py
@@ -184,11 +184,7 @@ class SchemathesisRunner:
             if endpoint_filter:
                 operations = [op for op in operations if endpoint_filter in op.path]
             if method_filter:
-                operations = [
-                    op
-                    for op in operations
-                    if op.method.upper() == method_filter.upper()
-                ]
+                operations = [op for op in operations if op.method.upper() == method_filter.upper()]
 
             task = progress.add_task(
                 f"Testing {len(operations)} operations...",
@@ -291,9 +287,7 @@ class SchemathesisRunner:
                 case = test_func.example()
                 yield case
         except Exception as e:  # pylint: disable=broad-exception-caught
-            console.print(
-                f"[yellow]Failed to generate cases for {operation.path}: {e}[/yellow]"
-            )
+            console.print(f"[yellow]Failed to generate cases for {operation.path}: {e}[/yellow]")
 
     def _execute_case(self, case: Case) -> Any:
         """Execute a test case against the API."""
@@ -316,9 +310,7 @@ class SchemathesisRunner:
 
         return self.auth.request(method, path, **kwargs)
 
-    def _make_schema_discrepancy(
-        self, case: Case, validation_error: BaseException
-    ) -> Discrepancy:
+    def _make_schema_discrepancy(self, case: Case, validation_error: BaseException) -> Discrepancy:
         """Create a schema validation discrepancy from a validation error."""
         return Discrepancy(
             path=case.path,
@@ -449,19 +441,13 @@ class SchemathesisRunner:
                     continue
 
         # Debug logging
-        console.print(
-            f"[cyan]DEBUG: Collected {len(results)} results from stateful tests[/cyan]"
-        )
-        console.print(
-            f"[cyan]DEBUG: self.results before extend: {len(self.results)}[/cyan]"
-        )
+        console.print(f"[cyan]DEBUG: Collected {len(results)} results from stateful tests[/cyan]")
+        console.print(f"[cyan]DEBUG: self.results before extend: {len(self.results)}[/cyan]")
 
         # Update self.results for get_summary()
         self.results.extend(results)
 
-        console.print(
-            f"[cyan]DEBUG: self.results after extend: {len(self.results)}[/cyan]"
-        )
+        console.print(f"[cyan]DEBUG: self.results after extend: {len(self.results)}[/cyan]")
         return results
 
     def _matches_crud_operation(

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -139,9 +139,7 @@ class ValidationOrchestrator:  # pylint: disable=too-many-instance-attributes
         console.print("[bold blue]F5 XC API Spec Validation[/bold blue]")
 
         if self.dry_run:
-            console.print(
-                "[yellow]Running in dry-run mode (no live API calls)[/yellow]"
-            )
+            console.print("[yellow]Running in dry-run mode (no live API calls)[/yellow]")
 
         # Step 1: Load and validate specs
         console.print("\n[bold]Step 1: Loading OpenAPI Specs[/bold]")
@@ -229,14 +227,10 @@ class ValidationOrchestrator:  # pylint: disable=too-many-instance-attributes
                 f"{sum(len(s.constraints) for s in schemas.values())} constraints[/dim]"
             )
 
-        console.print(
-            f"[green]Total: {len(all_constraints)} schemas with constraints[/green]"
-        )
+        console.print(f"[green]Total: {len(all_constraints)} schemas with constraints[/green]")
         return all_constraints
 
-    def _generate_test_cases(
-        self, constraints: dict
-    ) -> dict[str, list[ValidationTestCase]]:
+    def _generate_test_cases(self, constraints: dict) -> dict[str, list[ValidationTestCase]]:
         """Generate test cases for all constraints."""
         all_test_cases = {}
         total_tests = 0
@@ -313,12 +307,8 @@ class ValidationOrchestrator:  # pylint: disable=too-many-instance-attributes
                     # so the JSON report can surface them per entry).
                     for result in results:
                         self.discrepancies.extend(result.discrepancies)
-                        self.discrepancy_domains.extend(
-                            [domain_slug] * len(result.discrepancies)
-                        )
-                        self.discrepancy_methods.extend(
-                            [result.method] * len(result.discrepancies)
-                        )
+                        self.discrepancy_domains.extend([domain_slug] * len(result.discrepancies))
+                        self.discrepancy_methods.extend([result.method] * len(result.discrepancies))
 
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     console.print(f"  [red]Error testing {resource}: {e}[/red]")
@@ -330,9 +320,7 @@ class ValidationOrchestrator:  # pylint: disable=too-many-instance-attributes
     ) -> None:
         """Run constraint validation tests against live API."""
         if not self.auth:
-            console.print(
-                "[yellow]No auth configured, skipping constraint tests[/yellow]"
-            )
+            console.print("[yellow]No auth configured, skipping constraint tests[/yellow]")
             return
 
         endpoints_config = self.endpoints_config.get("endpoints", {})
@@ -430,9 +418,7 @@ class ValidationOrchestrator:  # pylint: disable=too-many-instance-attributes
 
 def main() -> int:
     """Main entry point for validation command."""
-    parser = argparse.ArgumentParser(
-        description="Validate F5 XC OpenAPI specs against live API"
-    )
+    parser = argparse.ArgumentParser(description="Validate F5 XC OpenAPI specs against live API")
     parser.add_argument(
         "--config",
         type=Path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,7 @@ def sample_openapi_spec() -> dict:
                             "description": "Success",
                             "content": {
                                 "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/TestResponse"
-                                    }
+                                    "schema": {"$ref": "#/components/schemas/TestResponse"}
                                 }
                             },
                         }

--- a/tests/test_discrepancy_fingerprint.py
+++ b/tests/test_discrepancy_fingerprint.py
@@ -2,9 +2,7 @@ from scripts.utils.constraint_validator import Discrepancy, DiscrepancyType
 from scripts.utils.discrepancy_fingerprint import fingerprint, short_form
 
 
-def _make(
-    path="/a", prop="foo", ctype="minLength", dtype=DiscrepancyType.SPEC_STRICTER
-):
+def _make(path="/a", prop="foo", ctype="minLength", dtype=DiscrepancyType.SPEC_STRICTER):
     return Discrepancy(
         path=path,
         property_name=prop,
@@ -23,9 +21,7 @@ def test_fingerprint_is_40_hex_chars():
 
 def test_fingerprint_is_stable_across_calls():
     d = _make()
-    assert fingerprint(d, "origin_pool", "POST") == fingerprint(
-        d, "origin_pool", "POST"
-    )
+    assert fingerprint(d, "origin_pool", "POST") == fingerprint(d, "origin_pool", "POST")
 
 
 def test_fingerprint_changes_with_any_input():
@@ -35,10 +31,7 @@ def test_fingerprint_changes_with_any_input():
     assert fingerprint(base, "app_firewall", "POST") != baseline
     assert fingerprint(_make(path="/b"), "origin_pool", "POST") != baseline
     assert fingerprint(_make(prop="bar"), "origin_pool", "POST") != baseline
-    assert (
-        fingerprint(_make(dtype=DiscrepancyType.SPEC_LOOSER), "origin_pool", "POST")
-        != baseline
-    )
+    assert fingerprint(_make(dtype=DiscrepancyType.SPEC_LOOSER), "origin_pool", "POST") != baseline
 
 
 def test_short_form_is_first_8_chars():
@@ -87,6 +80,4 @@ def test_fingerprint_tolerates_pipe_in_payload_fields():
         spec_value=1,
         api_behavior={},
     )
-    assert fingerprint(a, "origin_pool", "POST") != fingerprint(
-        b, "origin_pool", "POST"
-    )
+    assert fingerprint(a, "origin_pool", "POST") != fingerprint(b, "origin_pool", "POST")

--- a/tests/test_discrepancy_reprobe.py
+++ b/tests/test_discrepancy_reprobe.py
@@ -66,9 +66,7 @@ def test_spec_stricter_still_present_when_api_still_accepts():
     def handler(_req):
         return httpx.Response(201, json={"id": "abc"})
 
-    evidence = reprobe_discrepancy(
-        _stricter_disc(), "origin_pool", "POST", client=_client(handler)
-    )
+    evidence = reprobe_discrepancy(_stricter_disc(), "origin_pool", "POST", client=_client(handler))
     assert evidence.discrepancy_still_present is True
 
 
@@ -78,9 +76,7 @@ def test_spec_stricter_resolved_when_api_now_rejects():
     def handler(_req):
         return httpx.Response(400, json={"error": "value too small"})
 
-    evidence = reprobe_discrepancy(
-        _stricter_disc(), "origin_pool", "POST", client=_client(handler)
-    )
+    evidence = reprobe_discrepancy(_stricter_disc(), "origin_pool", "POST", client=_client(handler))
     assert evidence.discrepancy_still_present is False
 
 
@@ -90,9 +86,7 @@ def test_spec_looser_still_present_when_api_still_rejects():
     def handler(_req):
         return httpx.Response(400, json={"error": "name required"})
 
-    evidence = reprobe_discrepancy(
-        _looser_disc(), "origin_pool", "POST", client=_client(handler)
-    )
+    evidence = reprobe_discrepancy(_looser_disc(), "origin_pool", "POST", client=_client(handler))
     assert evidence.discrepancy_still_present is True
 
 
@@ -102,9 +96,7 @@ def test_spec_looser_resolved_when_api_now_accepts():
     def handler(_req):
         return httpx.Response(201, json={"id": "abc"})
 
-    evidence = reprobe_discrepancy(
-        _looser_disc(), "origin_pool", "POST", client=_client(handler)
-    )
+    evidence = reprobe_discrepancy(_looser_disc(), "origin_pool", "POST", client=_client(handler))
     assert evidence.discrepancy_still_present is False
 
 

--- a/tests/test_issue_sync.py
+++ b/tests/test_issue_sync.py
@@ -22,9 +22,7 @@ def _issue(num, fp, state="open"):
 
 def test_plan_creates_for_new_fingerprint():
     existing: list[dict] = []
-    current: dict[str, dict] = {
-        "abcd1234ffffffffffffffffffffffffffffffff": {"fake": "disc"}
-    }
+    current: dict[str, dict] = {"abcd1234ffffffffffffffffffffffffffffffff": {"fake": "disc"}}
     plan = compute_plan(existing, current)
     assert isinstance(plan, SyncPlan)
     assert plan.to_create == ["abcd1234ffffffffffffffffffffffffffffffff"]

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -52,8 +52,7 @@ def test_domain_from_filename_extracts_slug() -> None:
     )
     assert (
         _domain_from_filename(
-            "docs-cloud-f5-com.0001.public.ves.io.schema.api_sec.api_crawler."
-            "ves-swagger.json"
+            "docs-cloud-f5-com.0001.public.ves.io.schema.api_sec.api_crawler.ves-swagger.json"
         )
         == "api_sec.api_crawler"
     )

--- a/tests/test_spec_loader.py
+++ b/tests/test_spec_loader.py
@@ -97,21 +97,15 @@ class TestSpecLoader:
 
     def test_find_schema_by_ref(self, loader: SpecLoader, sample_openapi_spec: dict):
         """Test finding schema by $ref."""
-        schema = loader.find_schema_by_ref(
-            sample_openapi_spec, "#/components/schemas/TestRequest"
-        )
+        schema = loader.find_schema_by_ref(sample_openapi_spec, "#/components/schemas/TestRequest")
 
         assert schema is not None
         assert schema["type"] == "object"
         assert "properties" in schema
 
-    def test_find_schema_by_ref_not_found(
-        self, loader: SpecLoader, sample_openapi_spec: dict
-    ):
+    def test_find_schema_by_ref_not_found(self, loader: SpecLoader, sample_openapi_spec: dict):
         """Test finding non-existent schema by $ref."""
-        schema = loader.find_schema_by_ref(
-            sample_openapi_spec, "#/components/schemas/NonExistent"
-        )
+        schema = loader.find_schema_by_ref(sample_openapi_spec, "#/components/schemas/NonExistent")
 
         assert schema is None
 

--- a/tests/test_spectral_reconcile.py
+++ b/tests/test_spectral_reconcile.py
@@ -195,24 +195,18 @@ class TestSchemaRename:
                 "schemas": {
                     "routeRouteType": {"type": "string", "enum": ["A"]},
                     "other": {
-                        "properties": {
-                            "rt": {"$ref": "#/components/schemas/routeRouteType"}
-                        }
+                        "properties": {"rt": {"$ref": "#/components/schemas/routeRouteType"}}
                     },
                 },
             },
         }
-        result = rename_colliding_schemas(
-            spec, spectral_config, "foo.operate.route.json"
-        )
+        result = rename_colliding_schemas(spec, spectral_config, "foo.operate.route.json")
         assert "operateRouteRouteType" in result["components"]["schemas"]
         assert "routeRouteType" not in result["components"]["schemas"]
 
     def test_rename_skipped_for_non_matching_file(self, spectral_config):
         spec = {"components": {"schemas": {"routeRouteType": {"type": "object"}}}}
-        result = rename_colliding_schemas(
-            spec, spectral_config, "foo.schema.route.json"
-        )
+        result = rename_colliding_schemas(spec, spectral_config, "foo.schema.route.json")
         assert "routeRouteType" in result["components"]["schemas"]
 
 


### PR DESCRIPTION
Closes #691

## Problem

`ruff format --check` failed on **16 files** on an untouched `main`. They are written to roughly 88 columns while the repository configures 100 — `pyproject.toml` sets `line-length = 100` and `.ruff.toml` does `extend = "pyproject.toml"`, so 100 is the effective value everywhere.

## The decision the issue asked for

Resolved toward **100**, deliberately:

- It is the declared standard, set explicitly in `pyproject.toml`.
- **36 of 52** Python files already conform. The 16 are the drift, not the convention.
- Changing the config to 88 would move a repo-wide standard to match whichever files happened to be written against ruff's default — treating the symptom, which is exactly what #691 was filed to avoid after that shortcut was reverted during #686.

## Purely formatting, and proven

Beyond the test suite, the ASTs are identical before and after:

```
python files changed: 16
AST-identical: 16 | AST-DIFFERENT: 0
=> reformat is provably behaviour-preserving
```

Nothing else is touched, per the issue's request for a diff reviewable as pure formatting.

## Verification

- `ruff format --check .` → **52 files already formatted** (was 16 would-be-reformatted)
- `ruff check .` → All checks passed
- `pytest -q` → **256 passed, 1 skipped**
- `pylint --rcfile=.python-lint` on all 16 → **10.00/10**
- `mypy --config-file .mypy.ini` on all 16 → no issues
- `pre-commit run --files <changed>` → no failures

## Incidental finding, filed separately

Running mypy via `pyproject.toml` reports 4 `no-any-return` errors in `scripts/utils/github_issues.py` that CI never sees, because super-linter uses `PYTHON_MYPY_CONFIG_FILE=.mypy.ini`, where `warn_return_any = False` while `pyproject.toml` sets it `true`. Pre-existing — HEAD has 5, this branch has 4 — and not addressed here, but it is the same "local and CI disagree" class as #691 itself. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)