### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,11 @@
     "baseRef": "fresh"
   },
   "permissions": {
-    "deny": ["Skill(code-review:code-review)", "Skill(pr-review-toolkit:review-pr)"]
+    "deny": [
+      "Skill(code-review:code-review)",
+      "Skill(pr-review-toolkit:review-pr)",
+      "Skill(commit-commands:clean_gone)"
+    ]
   },
   "hooks": {
     "PreToolUse": [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,31 @@ updates:
           - "minor"
           - "patch"
 
+  # --- npm ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    groups:
+      # First-party @f5-sales-demo/* packages: track latest daily, all update types
+      # (auto-merged once CI is green) so internal deps never drift behind.
+      f5-internal:
+        patterns:
+          - "@f5-sales-demo/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   # --- pip ---
   - package-ecosystem: "pip"
     directory: "/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,10 @@ The Claude Code review is a **required, merge-gating check** that can block. On 
 ## Worktrees
 
 - For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
+- **Know where you are.** Before starting, run `git worktree list` and confirm the current directory belongs to the task at hand. Never begin new work in a worktree left over from a finished one — retire it and start fresh. A finished worktree looks unmerged (squash-merge) and its base is stale. Retiring has a required order and an ignored-file check first — see CONTRIBUTING.md.
 - New worktrees branch from `origin/<default-branch>` (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
 - `fresh` means "from the cached remote ref", not "freshly fetched" — it only re-fetches when `FETCH_HEAD` is over 24 hours old. A worktree created after an earlier same-day fetch is born behind whatever merged since, so fetch before you create one.
-- If a repository's build needs gitignored inputs (`.env`, secrets, local config), add a repo-local `.worktreeinclude` listing them so new worktrees carry those files in.
+- If a repository's build needs gitignored inputs (`.env`, secrets, local config), add a repo-local `.worktreeinclude` listing them so new worktrees carry those files in. Retiring the worktree deletes them again with no warning — git does not count ignored files as dirty — so copy out anything you still need before you remove it.
 
 ## Engineering Standards
 
@@ -71,7 +72,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup and per-session isolation of concurrent sessions.
+- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, retire your worktree, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches, leftover worktrees) unprompted — see CONTRIBUTING.md for the safe procedure.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,10 +266,12 @@ apply what fits.
   install, and exercise the published version to confirm the fix is real — not merely
   that the pipeline reported success.
 - Leaving a clean workspace is part of "done": once merge is confirmed and CI is green,
-  return to `main`, delete your merged local branch, and proactively report git hygiene
-  — current branch, uncommitted or unmerged changes, and any stale `[gone]` branches —
-  rather than waiting to be asked. See "After merge: clean up local branches" for the
-  safe confirm-then-delete steps.
+  retire the worktree you worked in, then return to `main`, delete your merged local
+  branch, and proactively report git hygiene — current branch, uncommitted or unmerged
+  changes, stale `[gone]` branches, and leftover worktrees — rather than waiting to be
+  asked. The worktree comes first; the branch cannot be deleted while it is still checked
+  out in one. See "After merge: clean up local branches and worktrees" for the safe
+  confirm-then-delete steps.
 
 ### No papering over problems
 
@@ -318,16 +320,51 @@ apply what fits.
   a session can find its own in-flight work:
   - `gh pr list --search "head:s-<slug>"` — this session's PRs
   - `git branch --list "s-<slug>/*"` — this session's local branches
-- Composes with the after-merge `[gone]` cleanup below: cleanup is naturally scoped per session,
-  and retiring the merged branch also removes its worktree.
+- Composes with the after-merge `[gone]` cleanup below: cleanup is naturally scoped per session.
+  Retiring the branch does **not** remove its worktree — that is a separate, explicit step, and it
+  is the one that gets skipped. Skipped worktrees are how a later session ends up starting new work
+  inside a finished one.
 - Advisory only — a local-workstation concern CI cannot enforce.
 
-#### After merge: clean up local branches
+#### After merge: clean up local branches and worktrees
 
 - The server deletes the remote branch on merge (`delete_branch_on_merge`); the local
   copy remains and must be cleaned up, or merged branches accumulate on the workstation.
-- Once your PR is merged and CI is green, return to `main` and prune:
-  `git checkout main && git pull && git fetch --prune`.
+  A worktree you worked in remains too, and nothing removes it for you.
+- If you worked in a worktree, retire it **first** — leave it, then remove it:
+
+  ```bash
+  git worktree list                       # audit: what exists, where you are, what is locked
+  git -C <path> status --short --ignored  # ignored files are about to be deleted — check first
+  # Only if THIS session created it, use ExitWorktree — it handles the lock.
+  # Otherwise (a leftover from an earlier session), from the MAIN checkout,
+  # and only once the owning session has ended:
+  git worktree unlock <path>              # Claude Code creates worktrees locked
+  git worktree remove <path>
+  ```
+
+  Run the `--ignored` check before removing anything. Removal deletes ignored files without
+  warning and without refusing: git does not count them as dirty, so a worktree holding a
+  `.env` reports a clean `git status --porcelain`, and `git worktree remove` exits 0 and
+  takes the file with it. This matters here because CLAUDE.md recommends `.worktreeinclude`
+  to carry exactly those files — `.env`, secrets, local config — into new worktrees. Copy out
+  anything you still need first. `ExitWorktree` removes the directory too, so the same
+  caution applies.
+
+  Order matters, and so does where you stand. `git branch -D` refuses while the branch is
+  still checked out somewhere (`error: cannot delete branch 'x' used by worktree at …`), so
+  the worktree goes first. Removing a worktree while your shell is inside it does succeed,
+  but it deletes the directory out from under you and the next command fails with
+  `fatal: Unable to read current working directory` — so leave before you remove.
+
+  Claude Code marks its worktrees `locked`, and a locked worktree cannot be removed:
+  `fatal: cannot remove a locked working tree`. Note that plain `--force` does **not**
+  override this — only `unlock` first, or `remove -f -f`. Prefer `unlock`: the double-force
+  also discards uncommitted changes, and a locked worktree usually means a session is still
+  using it. Confirm the owning session has ended before unlocking someone else's.
+- Then, in the main checkout, sync and prune: `git pull --ff-only && git fetch --prune`.
+  Do not reach for `git checkout main` from inside a worktree; `main` is checked out in the
+  main checkout, so it fails with `fatal: 'main' is already used by worktree at …`.
 - Pruning marks any branch whose upstream was deleted as `[gone]`. Squash-merges mean a
   merged branch is not an ancestor of `main` (so `git branch --merged` misses it) and
   `git branch -d` refuses it — removing it requires the force flag, `git branch -D`.


### PR DESCRIPTION
Closes #719

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- .claude/settings.json
- .github/dependabot.yml