### PR TITLE
fix: use one stable branch for the validation-report PR

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -714,13 +714,35 @@ jobs:
             echo "No docs changes"
             exit 0
           fi
-          BRANCH="docs/update-validation-report-$(date +%s)"
-          git checkout -b "${BRANCH}"
+          # One stable branch, force-updated, rather than a new timestamped branch per run.
+          #
+          # The old `docs/update-validation-report-$(date +%s)` orphaned any run whose PR was
+          # wedged on a transient check: the next run opened a different PR on a different
+          # branch and nothing ever revisited the stuck one. Twelve accumulated between
+          # 2026-06-12 and 2026-07-05 (#723). With a fixed branch a wedged run is repaired by
+          # the next one instead of abandoned, and at most one report PR is ever open.
+          #
+          # Same shape as docs-control's sync-managed-files, which uses the fixed
+          # `governance/sync-managed-files` branch for exactly this reason.
+          #
+          # The name still starts with `docs/update-`, which both gates require: it is in
+          # docs-control's EXCLUDE_BRANCHES for require-linked-issue, and in both branch lists
+          # in code-review.yml.
+          BRANCH="docs/update-validation-report"
+          # -B, not -b: the branch may already exist locally on a re-run, and -b would abort.
+          git checkout -B "${BRANCH}"
           git commit -m "docs: update validation report"
-          git push origin "${BRANCH}"
-          gh pr create --title "docs: update validation report" \
-            --body "Auto-generated from validation pipeline run."
-          gh pr merge --auto --squash
+          git push --force origin "${BRANCH}"
+
+          # Reuse the open PR if there is one; --force above has already updated its head.
+          if [ -z "$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[].number')" ]; then
+            gh pr create --title "docs: update validation report" \
+              --body "Auto-generated from validation pipeline run." \
+              --head "${BRANCH}"
+          else
+            echo "Refreshed the existing PR for ${BRANCH}."
+          fi
+          gh pr merge --auto --squash "${BRANCH}"
 
   commit-release-specs:
     name: Publish Regenerated Specs


### PR DESCRIPTION
Closes #723

## Problem

`update-docs` created a new branch every run:

```bash
BRANCH="docs/update-validation-report-$(date +%s)"
```

If a run's PR wedged on a transient check, auto-merge never fired — and nothing ever revisited it. The next run opened a *different* PR on a *different* branch, which merged fine, permanently orphaning the stuck one.

**Twelve** accumulated between 2026-06-12 and 2026-07-05. All changed the same single file, `docs/01-validation-report.mdx`. Each was blocked on a different transient failure — `audit / Translation freshness`, `lint / Lint Code Base`, `check / Check linked issues`. All now closed as superseded; this PR stops the pile rebuilding.

The cost was not just tidiness: twelve open PRs hid real ones (#497 sat in that list for over a month), and "PRs with failing checks" stopped being a usable signal.

## Fix

One fixed branch, force-updated each run, with the PR created only when none is open:

```bash
BRANCH="docs/update-validation-report"
git checkout -B "${BRANCH}"
git commit -m "docs: update validation report"
git push --force origin "${BRANCH}"

if [ -z "$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[].number')" ]; then
  gh pr create ... --head "${BRANCH}"
else
  echo "Refreshed the existing PR for ${BRANCH}."
fi
gh pr merge --auto --squash "${BRANCH}"
```

A wedged run is now repaired by the next one instead of abandoned, and at most one report PR is ever open.

**Not a new invention** — docs-control's `sync-managed-files` already does exactly this with its fixed `governance/sync-managed-files` branch (`sync-managed-files.yml:625-637`).

## Gate compatibility, verified not assumed

The stable name must still clear two independently-configured gates:

| Gate | Pattern | `docs/update-validation-report` |
| ---- | ------- | ------------------------------- |
| `require-linked-issue` (docs-control `EXCLUDE_BRANCHES`) | `docs/update-*`, where `*` → `[^/]*` | matches |
| `code-review.yml` (both branch lists) | `startsWith(head_ref, 'docs/update-')` | matches |

Checked by evaluating the actual glob-to-regex conversion the linked-issue check uses, rather than by eye.

## Other details

- `-B` rather than `-b`: a re-run with the branch already present locally would abort on `-b`.
- The existing `git diff --cached --quiet` no-op guard is unchanged, so an unchanged report still opens nothing.

## Verification

- YAML parses; 8 jobs intact.
- The `run` block extracted and passed through `shellcheck -S warning` — clean.
- `pre-commit run --files .github/workflows/validate-and-release.yml` — all hooks pass, including `GitHub Actions lint` and `GitHub Actions security` (zizmor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)