### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -2,7 +2,7 @@
   "spec_date": "2026.07.24",
   "spec_timestamp": "2026-07-24T17:30:26+00:00",
   "download_date": "2026.07.27",
-  "download_timestamp": "2026-07-27T21:00:15.668505+00:00",
+  "download_timestamp": "2026-07-27T21:18:38.791457+00:00",
   "etag": "W/\"33e92e-19f952dab50\"",
   "last_modified": "Fri, 24 Jul 2026 17:30:26 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.