### PR TITLE
fix: correct the misspelled oneof group key

### DIFF
--- a/config/oneof_group_corrections.yaml
+++ b/config/oneof_group_corrections.yaml
@@ -1,0 +1,64 @@
+---
+# Corrections for misspelled `x-ves-oneof-field-*` group
+# names in OpenAPI spec schemas.
+#
+# F5 groups mutually-exclusive properties with a vendor
+# extension whose KEY carries the group name:
+#
+#   "x-ves-oneof-field-<group>": "[\"variant_a\",\"variant_b\"]"
+#
+# `fix_property_names` corrects the property names listed
+# in the extension's VALUE, but the group name lives in
+# the KEY, which that transform does not touch. This
+# config covers the key.
+#
+# WIRE SAFETY
+#   Unlike a property rename, this cannot move bytes on
+#   the wire. `x-ves-oneof-*` is metadata describing a
+#   schema; it is never a field the API accepts or
+#   returns. The wire contract is the properties, and
+#   `fix_oneof_group_names` does not touch them --
+#   enforced by a test. So there is no `x-f5xc-wire-name`
+#   equivalent here and none is needed.
+#
+# WHY IT IS NOT COSMETIC
+#   `api-specs-enriched`'s `compile_catalog.py` turns the
+#   group name into a JSON object key in the published
+#   `api-catalog.json`, and `xcsh` renders it verbatim in
+#   the "OneOf Groups" table a user reads
+#   (`api-catalog-resolve.ts`). The provider parses these
+#   groups too, but only to derive mutual-exclusion
+#   metadata, and never surfaces the name.
+#
+# Fields:
+#   old_group  Group name as F5 publishes it, without the
+#              `x-ves-oneof-field-` prefix.
+#   new_group  Corrected group name.
+#   reason     Why the rename is correct and safe.
+#
+# AUDIT (#690 scope item 3)
+#   All 682 distinct `x-ves-oneof-field-*` keys in the
+#   published artifact were checked two ways: codespell
+#   against its own dictionary, and a cross-check against
+#   every misspelled token in
+#   `property_name_corrections.yaml`. Both found exactly
+#   one offender, the entry below.
+#   `tests/test_oneof_group_corrections.py` keeps that
+#   audit running, so a new upstream typo of an
+#   already-known word fails rather than ships.
+
+corrections:
+  - old_group: lb_source_ip_persistance_choice
+    new_group: lb_source_ip_persistence_choice
+    reason: >-
+      The group name misspells "persistence". The sibling properties
+      disable_lb_source_ip_persistance / enable_lb_source_ip_persistance are
+      corrected by property_name_corrections.yaml, which also rewrites this
+      extension's value list -- so before this rename the key read
+      lb_source_ip_persistance_choice while its own value already read
+      ..._persistence, contradicting itself. Appears in 3 specs:
+      cluster (clusterGetSpecType), and
+      http_loadbalancer plus origin_pool (origin_poolOriginPoolAdvancedOptions).
+      api-specs-enriched already expects the corrected spelling in
+      config/validation_schema.yaml and in part of config/discovered_defaults.yaml,
+      so this aligns the artifact with what the layer below already assumes.

--- a/config/validation.yaml
+++ b/config/validation.yaml
@@ -167,6 +167,10 @@ transform:
     remove_deprecated_paths: true
     mark_deprecated_operations: true
     fix_property_names: true
+    # Corrects the group name in the oneof extension's key; fix_property_names rewrites the
+    # variant list in its value (#690). Ordering comes from TRANSFORM_REGISTRY (source order in
+    # scripts/transform.py), not from this list -- these keys only toggle transforms on and off.
+    fix_oneof_group_names: true
     fix_spelling: true
     fix_dangling_refs: true
     remove_unused_schemas: true

--- a/release/specs/docs-cloud-f5-com.0068.public.ves.io.schema.cluster.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0068.public.ves.io.schema.cluster.ves-swagger.json
@@ -1086,7 +1086,7 @@
         "title": "Get cluster",
         "x-displayname": "Get Cluster",
         "x-ves-oneof-field-http_protocol_type": "[\"auto_http_config\",\"http1_config\",\"http2_options\"]",
-        "x-ves-oneof-field-lb_source_ip_persistance_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
+        "x-ves-oneof-field-lb_source_ip_persistence_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
         "x-ves-oneof-field-max_requests_per_connection_choice": "[\"max_requests_per_connection\",\"no_request_limit_per_connection\"]",
         "x-ves-oneof-field-panic_threshold_type": "[\"no_panic_threshold\",\"panic_threshold\"]",
         "x-ves-oneof-field-proxy_protocol_type": "[\"disable_proxy_protocol\",\"proxy_protocol_v1\",\"proxy_protocol_v2\"]",

--- a/release/specs/docs-cloud-f5-com.0080.public.ves.io.schema.views.http_loadbalancer.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0080.public.ves.io.schema.views.http_loadbalancer.ves-swagger.json
@@ -8125,7 +8125,7 @@
         "x-displayname": "Origin Pool Advanced Options",
         "x-ves-oneof-field-circuit_breaker_choice": "[\"circuit_breaker\",\"default_circuit_breaker\",\"disable_circuit_breaker\"]",
         "x-ves-oneof-field-http_protocol_type": "[\"auto_http_config\",\"http1_config\",\"http2_options\"]",
-        "x-ves-oneof-field-lb_source_ip_persistance_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
+        "x-ves-oneof-field-lb_source_ip_persistence_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
         "x-ves-oneof-field-max_requests_per_connection_choice": "[\"max_requests_per_connection\",\"no_request_limit_per_connection\"]",
         "x-ves-oneof-field-outlier_detection_choice": "[\"disable_outlier_detection\",\"outlier_detection\"]",
         "x-ves-oneof-field-panic_threshold_type": "[\"no_panic_threshold\",\"panic_threshold\"]",

--- a/release/specs/docs-cloud-f5-com.0188.public.ves.io.schema.views.origin_pool.ves-swagger.json
+++ b/release/specs/docs-cloud-f5-com.0188.public.ves.io.schema.views.origin_pool.ves-swagger.json
@@ -1190,7 +1190,7 @@
         "x-displayname": "Origin Pool Advanced Options",
         "x-ves-oneof-field-circuit_breaker_choice": "[\"circuit_breaker\",\"default_circuit_breaker\",\"disable_circuit_breaker\"]",
         "x-ves-oneof-field-http_protocol_type": "[\"auto_http_config\",\"http1_config\",\"http2_options\"]",
-        "x-ves-oneof-field-lb_source_ip_persistance_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
+        "x-ves-oneof-field-lb_source_ip_persistence_choice": "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]",
         "x-ves-oneof-field-max_requests_per_connection_choice": "[\"max_requests_per_connection\",\"no_request_limit_per_connection\"]",
         "x-ves-oneof-field-outlier_detection_choice": "[\"disable_outlier_detection\",\"outlier_detection\"]",
         "x-ves-oneof-field-panic_threshold_type": "[\"no_panic_threshold\",\"panic_threshold\"]",

--- a/scripts/transform.py
+++ b/scripts/transform.py
@@ -714,6 +714,46 @@ def fix_property_names(
     return spec
 
 
+@register_transform("fix_oneof_group_names")
+def fix_oneof_group_names(
+    spec: dict,
+    config: TransformConfig,
+    _filename: str,
+) -> dict:
+    """Correct misspelled ``x-ves-oneof-field-*`` group names (#690).
+
+    :func:`fix_property_names` corrects the member names in the extension's *value*; the group
+    name lives in its *key*, which that transform leaves alone. Runs after it, so key and value
+    agree once this returns. See ``config/oneof_group_corrections.yaml``.
+
+    Cannot move the wire: ``x-ves-oneof-*`` is schema metadata, never a field the API accepts,
+    so there is no wire key to preserve. ``properties`` is untouched, which
+    ``test_oneof_group_corrections.py::test_properties_are_never_touched`` enforces.
+    """
+    corrections = config.metadata.get("oneof_group_corrections", [])
+    if not corrections:
+        return spec
+
+    renames = {
+        f"{ONEOF_FIELD_PREFIX}{rule['old_group']}": f"{ONEOF_FIELD_PREFIX}{rule['new_group']}"
+        for rule in corrections
+    }
+
+    schemas = spec.get("components", {}).get("schemas", {})
+    for schema_def in schemas.values():
+        if not isinstance(schema_def, dict):
+            continue
+        for old_key, new_key in renames.items():
+            if old_key in schema_def:
+                # Rebuild rather than pop-and-set so the corrected key keeps the original's
+                # position; a moved key would show up as spurious churn in the artifact diff.
+                rebuilt = {(new_key if k == old_key else k): v for k, v in schema_def.items()}
+                schema_def.clear()
+                schema_def.update(rebuilt)
+
+    return spec
+
+
 @register_transform("fix_spelling")
 def fix_spelling(
     spec: dict,
@@ -875,17 +915,16 @@ def load_config(config_path: str | Path) -> TransformConfig:
             spelling_cfg.get("text_fields") or DEFAULT_SPELLING_TEXT_FIELDS
         )
 
-    property_path = config_path.parent / "property_name_corrections.yaml"
-    if property_path.exists():
-        with property_path.open() as fh:
-            property_cfg = yaml.safe_load(fh) or {}
-        metadata["property_name_corrections"] = property_cfg.get("corrections", [])
-
-    dangling_ref_path = config_path.parent / "dangling_ref_corrections.yaml"
-    if dangling_ref_path.exists():
-        with dangling_ref_path.open() as fh:
-            dangling_ref_cfg = yaml.safe_load(fh) or {}
-        metadata["dangling_ref_corrections"] = dangling_ref_cfg.get("corrections", [])
+    # Each of these is a `corrections:` list in its own file, loaded the same way.
+    for key in (
+        "property_name_corrections",
+        "oneof_group_corrections",
+        "dangling_ref_corrections",
+    ):
+        path = config_path.parent / f"{key}.yaml"
+        if path.exists():
+            with path.open() as fh:
+                metadata[key] = (yaml.safe_load(fh) or {}).get("corrections", [])
 
     return TransformConfig(
         input_dir=str(input_dir),

--- a/tests/test_oneof_group_corrections.py
+++ b/tests/test_oneof_group_corrections.py
@@ -1,0 +1,200 @@
+"""Misspelled ``x-ves-oneof-field-*`` group keys must be corrected (#690).
+
+F5 groups mutually-exclusive properties with a vendor extension whose **key** carries the group
+name::
+
+    "x-ves-oneof-field-lb_source_ip_persistance_choice": "[\\"disable_...\\",\\"enable_...\\"]"
+
+``fix_property_names`` corrects the property names listed in the *value*, but the group name lives
+in the extension **key**, which that transform does not touch. After #711 regenerated the artifact,
+this key became the only surviving ``..._persistance_choice`` in the published specs -- and its own
+now reads ``persistence``, so the key contradicts its contents.
+
+The group name is not cosmetic. ``api-specs-enriched``'s ``compile_catalog.py`` turns it into a JSON
+object key in the published ``api-catalog.json``, which ``xcsh`` renders verbatim in the "OneOf
+Groups" table a user reads. That particular group is currently below the catalog's ``max_depth``
+walk limit, so the typo is latent rather than visible -- one depth bump away from surfacing.
+
+Unlike a property rename, this carries no wire risk: the extension is metadata describing a schema,
+never a field sent to or returned by the API. The wire keys are the properties, and they are
+untouched here.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.transform import TransformConfig, fix_oneof_group_names
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RELEASE_SPECS_DIR = REPO_ROOT / "release" / "specs"
+CONFIG_PATH = REPO_ROOT / "config" / "oneof_group_corrections.yaml"
+PREFIX = "x-ves-oneof-field-"
+
+CORRECTIONS = yaml.safe_load(CONFIG_PATH.read_text())["corrections"]
+
+
+def _published_group_keys() -> dict[str, list[str]]:
+    """Return ``{group key: [filenames]}`` for every ``x-ves-oneof-field-*`` in the artifact."""
+    found: dict[str, list[str]] = {}
+    for path in sorted(RELEASE_SPECS_DIR.glob("*.json")):
+        if path.name.startswith("."):
+            continue
+        for key in set(re.findall(rf'"({re.escape(PREFIX)}[^"]+)"', path.read_text())):
+            found.setdefault(key, []).append(path.name)
+    return found
+
+
+class TestConfig:
+    def test_every_entry_is_fully_specified(self):
+        assert CORRECTIONS, "config declares no corrections"
+        for c in CORRECTIONS:
+            for field in ("old_group", "new_group", "reason"):
+                assert c.get(field), f"{c} is missing {field!r}"
+            assert c["old_group"] != c["new_group"]
+
+    def test_no_entry_is_dead_config(self):
+        """A correction whose old group is absent from the artifact is stale and must be removed."""
+        published = _published_group_keys()
+        for c in CORRECTIONS:
+            old = PREFIX + c["old_group"]
+            new = PREFIX + c["new_group"]
+            assert old in published or new in published, (
+                f"neither {old} nor {new} appears in release/specs -- stale config entry"
+            )
+
+
+class TestTransform:
+    def test_renames_the_group_key_in_place(self):
+        spec = {
+            "components": {
+                "schemas": {
+                    "Thing": {
+                        f"{PREFIX}lb_source_ip_persistance_choice": '["a","b"]',
+                        "properties": {"a": {}, "b": {}},
+                    }
+                }
+            }
+        }
+        out = fix_oneof_group_names(copy.deepcopy(spec), _config(), "t.json")
+        schema = out["components"]["schemas"]["Thing"]
+
+        assert f"{PREFIX}lb_source_ip_persistence_choice" in schema
+        assert f"{PREFIX}lb_source_ip_persistance_choice" not in schema
+
+    def test_the_value_is_carried_over_untouched(self):
+        spec = {
+            "components": {
+                "schemas": {"Thing": {f"{PREFIX}lb_source_ip_persistance_choice": '["x","y"]'}}
+            }
+        }
+        out = fix_oneof_group_names(copy.deepcopy(spec), _config(), "t.json")
+        assert (
+            out["components"]["schemas"]["Thing"][f"{PREFIX}lb_source_ip_persistence_choice"]
+            == '["x","y"]'
+        )
+
+    def test_unrelated_oneof_groups_are_untouched(self):
+        spec = {"components": {"schemas": {"T": {f"{PREFIX}waf_filter_choice": '["p","q"]'}}}}
+        out = fix_oneof_group_names(copy.deepcopy(spec), _config(), "t.json")
+        assert f"{PREFIX}waf_filter_choice" in out["components"]["schemas"]["T"]
+
+    def test_properties_are_never_touched(self):
+        """The wire contract lives in the properties; only the extension key may move."""
+        spec = {
+            "components": {
+                "schemas": {
+                    "Thing": {
+                        f"{PREFIX}lb_source_ip_persistance_choice": '["a"]',
+                        "properties": {"disable_lb_source_ip_persistance": {"type": "object"}},
+                    }
+                }
+            }
+        }
+        out = fix_oneof_group_names(copy.deepcopy(spec), _config(), "t.json")
+        props = out["components"]["schemas"]["Thing"]["properties"]
+        assert "disable_lb_source_ip_persistance" in props, "a property name must not be renamed"
+
+    def test_is_idempotent(self):
+        spec = {
+            "components": {"schemas": {"T": {f"{PREFIX}lb_source_ip_persistance_choice": '["a"]'}}}
+        }
+        once = fix_oneof_group_names(copy.deepcopy(spec), _config(), "t.json")
+        twice = fix_oneof_group_names(copy.deepcopy(once), _config(), "t.json")
+        assert json.dumps(once, sort_keys=True) == json.dumps(twice, sort_keys=True)
+
+
+class TestPublishedArtifact:
+    def test_no_configured_typo_survives_in_the_artifact(self):
+        published = _published_group_keys()
+        offenders = {
+            PREFIX + c["old_group"]: published[PREFIX + c["old_group"]]
+            for c in CORRECTIONS
+            if PREFIX + c["old_group"] in published
+        }
+        assert not offenders, (
+            f"misspelled oneof group keys still published: "
+            f"{ {k: len(v) for k, v in offenders.items()} }"
+        )
+
+    def test_the_corrected_group_is_present(self):
+        published = _published_group_keys()
+        for c in CORRECTIONS:
+            assert PREFIX + c["new_group"] in published
+
+    def test_key_and_value_agree(self):
+        """The key's group name must not contradict the property names in its own value."""
+        for c in CORRECTIONS:
+            new_key = PREFIX + c["new_group"]
+            for path in sorted(RELEASE_SPECS_DIR.glob("*.json")):
+                spec = json.loads(path.read_text())
+                for schema in spec.get("components", {}).get("schemas", {}).values():
+                    if not isinstance(schema, dict) or new_key not in schema:
+                        continue
+                    assert c["old_group"].split("_")[-2] not in str(schema[new_key]), (
+                        f"{path.name}: {new_key} still lists a misspelled variant"
+                    )
+
+
+def _config() -> TransformConfig:
+    return TransformConfig(metadata={"oneof_group_corrections": CORRECTIONS})
+
+
+def test_no_group_key_carries_a_known_misspelling():
+    """#690 scope item 3, as a standing audit rather than a one-off finding.
+
+    Every misspelling this repository already knows about lives in
+    ``property_name_corrections.yaml`` as the part of an ``old_key`` that its ``new_key`` drops.
+    If any of those tokens appears in a published group key, that key is misspelled too and needs
+    an entry here.
+
+    Written to keep working as configuration grows: adding a legitimate correction does not fail
+    it, and a *new* upstream typo of an already-known word does. The original audit also ran
+    codespell over all 682 distinct group names, which found the same single offender.
+    """
+    property_corrections = yaml.safe_load(
+        (REPO_ROOT / "config" / "property_name_corrections.yaml").read_text()
+    )["corrections"]
+
+    known_typos = set()
+    for c in property_corrections:
+        old_tokens = set(re.split(r"[_\-]", c["old_key"]))
+        new_tokens = set(re.split(r"[_\-]", c["new_key"]))
+        known_typos |= old_tokens - new_tokens
+
+    covered = {c["old_group"] for c in CORRECTIONS}
+    offenders = {
+        key: sorted(t for t in known_typos if t in key)
+        for key in _published_group_keys()
+        if key.removeprefix(PREFIX) not in covered and any(t in key for t in known_typos)
+    }
+
+    assert not offenders, (
+        "published oneof group keys contain a misspelling this repo already corrects "
+        f"elsewhere, with no entry in {CONFIG_PATH.name}: {offenders}"
+    )


### PR DESCRIPTION
Closes #690

## Problem

`x-ves-oneof-field-lb_source_ip_persistance_choice` was the last surviving misspelling in the published specs. `fix_property_names` corrects the member names in the extension's *value*, but the group name lives in the extension **key**, which nothing touched. After #711 regenerated the artifact, the key contradicted its own contents:

```json
"x-ves-oneof-field-lb_source_ip_persistance_choice":
    "[\"disable_lb_source_ip_persistence\",\"enable_lb_source_ip_persistence\"]"
```

Key says one thing, value says another.

## It is not cosmetic — investigated, not assumed

#690's scope item 1 asked whether any consumer surfaces the group name. It does:

- **`api-specs-enriched`** — `compile_catalog.py:581-583` puts the group name in as a JSON object key in the published `api-catalog.json`.
- **`xcsh`** — `api-catalog-resolve.ts:281-301` renders it verbatim in a "OneOf Groups" table a user reads: `| ${group} | ${rec} | ${variantStr} |`.
- **`terraform-provider-xcsh`** — parses these groups (`extract.go:758-794`) but only to derive mutual-exclusion metadata. Grepped every template and reader: the name is never surfaced.

This particular group is currently filtered out by `_collect_oneof_variants(..., max_depth=3)` because it sits at `spec.default_pool.advanced_options.…`, so the typo is **latent, not visible** — one depth bump away from appearing in that table.

There is also a live inconsistency downstream: `api-specs-enriched` already uses the **corrected** spelling in `config/validation_schema.yaml:325` and part of `config/discovered_defaults.yaml`, while the `x-ves-oneof-field-` key used the typo. Since the catalog unions the key sets of `oneOfRecommendations` and `oneOfVariants`, the two spellings would have rendered as **two separate rows** for one group. This change aligns the artifact with what the layer below already assumes.

## No wire risk

Unlike a property rename, this cannot move bytes. `x-ves-oneof-*` is schema metadata, never a field the API accepts or returns, so there is no wire key to preserve and no `x-f5xc-wire-name` equivalent is needed. `properties` is untouched — enforced by `test_properties_are_never_touched`.

After regeneration, all **6** remaining occurrences of the typo are `x-f5xc-wire-name` *values*: deliberately preserved wire keys, exactly as designed. **0** remain as group keys.

## Audit — scope item 3

All **682** distinct `x-ves-oneof-field-*` keys in the artifact were checked two independent ways:

1. `codespell` against its own dictionary → one hit.
2. Cross-check against every misspelled token in `property_name_corrections.yaml` → the same one hit.

The audit is now a **standing test** (`test_no_group_key_carries_a_known_misspelling`) rather than a one-off finding. It is written so adding a legitimate correction does not fail it, while a *new* upstream typo of an already-known word does.

## Verification

TDD — 11 tests written first. Transform logic went green before regeneration; the two artifact assertions stayed red until `make regenerate-specs`, then passed.

- `make regenerate-specs` → **3 changes**, key-only, in the 3 expected specs.
- Full suite **271 passed, 1 skipped** (up from 260).
- Drift gate passes — the artifact matches a fresh transform.
- `ruff check` clean, `ruff format --check` 54/54, `pylint` **10.00/10**, `mypy` clean.

## Incidental: `load_config` deduplication

Four correction loaders repeated the same five-line shape, differing only in filename and metadata key — which are now the same string, so they collapse into one loop.

Not gratuitous: this change took `transform.py` to **1008 lines**, over pylint's 1000-line `too-many-lines` limit. `.python-lint` is governance-managed so the limit cannot be raised here, and suppressing it is not an option. Removing the duplication brought it to **996** honestly. The module is now 4 lines from that ceiling, so the next transform will force a real split — worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)