### PR TITLE
test: guard hero structural fields against a bad retranslation

### DIFF
--- a/tests/test_hero_frontmatter.py
+++ b/tests/test_hero_frontmatter.py
@@ -1,0 +1,108 @@
+"""Translated hero blocks must keep their structural fields (#736).
+
+``docs/*/index.mdx`` carries a Starlight ``hero`` block whose ``actions`` mix two kinds of field::
+
+    hero:
+      actions:
+        - text: Pipeline Overview      # user-visible -- must be translated
+          link: 02-pipeline/           # structural -- must NOT be translated
+          icon: right-arrow            # structural
+          variant: primary             # structural
+
+Translating a structural field breaks the page: a translated ``link`` is a dead route, and a
+translated ``icon`` or ``variant`` is not a value Starlight recognises.
+
+This has gone wrong before. #420 and #427 were filed the same day with the identical body
+"Retranslation with fixed translator.", and #428 was the retranslation that repaired the hero
+fields. Nothing prevented a recurrence: the fleet translation audit reports only ``MISSING`` and
+``STALE``, comparing a stored ``sourceHash`` against the English file without ever looking inside
+the frontmatter. A future retranslation could turn ``link: 02-pipeline/`` into twelve dead links
+with every check still green -- greener, in fact, since the ``sourceHash`` would be correctly
+restamped.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS = REPO_ROOT / "docs"
+SOURCE_LOCALE = "en"
+
+# Not a locale: `superpowers` is skill documentation that sits alongside the translated tree.
+NON_LOCALE_DIRS = {"superpowers"}
+
+# Fields that identify or configure the action rather than describe it to a reader.
+STRUCTURAL_FIELDS = ("link", "icon", "variant")
+
+FRONTMATTER = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
+
+
+def _frontmatter(path: Path) -> dict:
+    match = FRONTMATTER.match(path.read_text())
+    assert match, f"{path} has no YAML frontmatter"
+    return yaml.safe_load(match.group(1)) or {}
+
+
+def _locales() -> list[str]:
+    return sorted(
+        p.name
+        for p in DOCS.iterdir()
+        if p.is_dir() and p.name != SOURCE_LOCALE and p.name not in NON_LOCALE_DIRS
+        if (p / "index.mdx").exists()
+    )
+
+
+@pytest.fixture(scope="module")
+def english_hero() -> dict:
+    return _frontmatter(DOCS / SOURCE_LOCALE / "index.mdx")["hero"]
+
+
+def test_locale_discovery_is_not_vacuous():
+    """A discovery bug that finds no locales would make every other test here pass silently."""
+    locales = _locales()
+    assert len(locales) >= 10, f"expected the full translated set, found {locales}"
+    assert SOURCE_LOCALE not in locales
+
+
+@pytest.mark.parametrize("locale", _locales())
+def test_structural_fields_are_identical_to_english(locale, english_hero):
+    """``link``, ``icon`` and ``variant`` must survive translation byte-for-byte."""
+    translated = _frontmatter(DOCS / locale / "index.mdx")["hero"]
+    en_actions = english_hero["actions"]
+    actions = translated["actions"]
+
+    assert len(actions) == len(en_actions), (
+        f"{locale}: hero has {len(actions)} actions, English has {len(en_actions)}"
+    )
+
+    for index, (action, en_action) in enumerate(zip(actions, en_actions, strict=True)):
+        for field in STRUCTURAL_FIELDS:
+            assert action.get(field) == en_action.get(field), (
+                f"{locale}: hero.actions[{index}].{field} is "
+                f"{action.get(field)!r}, expected {en_action.get(field)!r}. "
+                "Structural fields must not be translated -- a translated link is a dead "
+                "route, and a translated icon or variant is not a value Starlight knows."
+            )
+
+
+@pytest.mark.parametrize("locale", _locales())
+def test_visible_text_is_actually_translated(locale, english_hero):
+    """The flip side: leaving ``text`` in English means the action was skipped, not translated."""
+    translated = _frontmatter(DOCS / locale / "index.mdx")["hero"]
+
+    for index, (action, en_action) in enumerate(
+        zip(translated["actions"], english_hero["actions"], strict=True)
+    ):
+        assert action["text"] != en_action["text"], (
+            f"{locale}: hero.actions[{index}].text is still the English {en_action['text']!r}"
+        )
+
+    assert translated.get("tagline"), f"{locale}: hero.tagline is missing"
+    assert translated["tagline"] != english_hero["tagline"], (
+        f"{locale}: hero.tagline is still the English text"
+    )


### PR DESCRIPTION
Closes #736

## Why this exists

`docs/*/index.mdx` has a Starlight `hero` block whose `actions` mix two kinds of field:

```yaml
hero:
  actions:
    - text: Pipeline Overview      # user-visible — must be translated
      link: 02-pipeline/           # structural — must NOT be translated
      icon: right-arrow            # structural
      variant: primary             # structural
```

Translating a structural field breaks the page. A translated `link` is a dead route; a translated `icon` or `variant` is not a value Starlight recognises.

**It has gone wrong before.** #420 and #427 were filed the same day with the identical body *"Retranslation with fixed translator."*, and #428 was the retranslation that repaired the hero fields.

**Nothing prevented a recurrence**, which is what this PR fixes:

- The fleet translation audit (`docs-control/.github/workflows/translation-audit.yml`) reports only `MISSING` and `STALE`. It compares a stored `sourceHash` against the English file and never inspects the frontmatter.
- `grep -rln 'hero' tests/` returned nothing.

So a future retranslation could turn `link: 02-pipeline/` into twelve dead links with every check green — greener, in fact, since the `sourceHash` would be correctly restamped.

## No repair needed — this is purely a guard

Verified the current tree before writing anything. All 12 locales keep structural fields byte-identical to English, translate every `text`, and carry `sourceHash: 5c80e90cf718`, which matches the computed `sha256(docs/en/index.mdx)[:12]`. The CI freshness gate agrees independently.

## Proven by mutation, not argument

A guard that has never failed proves nothing, so each failure mode was induced and observed:

| Mutation | Result |
| -------- | ------ |
| `link: 02-pipeline/` → `パイプライン/` | `ja: hero.actions[0].link is 'パイプライン/', expected '02-pipeline/'` |
| `text: パイプライン概要` → `Pipeline Overview` | `ja: hero.actions[0].text is still the English 'Pipeline Overview'` |
| drop one action | `ja: hero has 1 actions, English has 2` |

Each reverted cleanly afterwards. There is also a vacuity guard: a locale-discovery bug that found nothing would otherwise make all 24 parametrised assertions pass silently.

## Verification

- Full suite **298 passed, 1 skipped** (up from 273 — 25 new).
- `ruff check` clean, `ruff format --check` 55/55, `pylint` **10.00/10**, `mypy` clean.
- Runs in CI via the existing `Python test suite` workflow; no new wiring.

## About #420

Researched rather than left open. #420 and #427 are duplicates — identical bodies, filed the same day. #427's PR #428 merged at 13:12 on 2026-06-09; #420's PR #421 was closed unmerged at 14:48, i.e. **after** #428 landed, superseded by it. #427 is closed; #420 was simply never closed. Closing it separately with this evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)