### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,8 +1,8 @@
 {
   "spec_date": "2026.07.28",
   "spec_timestamp": "2026-07-28T20:57:29+00:00",
-  "download_date": "2026.07.29",
-  "download_timestamp": "2026-07-29T08:38:34.197757+00:00",
+  "download_date": "2026.07.30",
+  "download_timestamp": "2026-07-30T08:24:23.969672+00:00",
   "etag": "W/\"33e92e-19faa84aaa8\"",
   "last_modified": "Tue, 28 Jul 2026 20:57:29 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.