### PR TITLE
fix(release): dispatch exact verified receipt

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -47,17 +47,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # Need full history for tags
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js (for Spectral)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           # Now that a lockfile exists, setup-node can key the npm cache off it.
@@ -78,7 +78,7 @@ jobs:
           echo "${GITHUB_WORKSPACE}/node_modules/.bin" >> "${GITHUB_PATH}"
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Get previous ETag from cache
         id: prev_etag
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .etag_cache
           key: etag-${{ github.sha }}
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload issue mapping artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: issue-mapping
           path: reports/issue_mapping.json
@@ -217,21 +217,21 @@ jobs:
         # its report is the only place the offending rule and file are
         # recorded in full.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: validation-reports
           path: reports/
           retention-days: 30
 
       - name: Upload reconciled specs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reconciled-specs
           path: release/specs/
           retention-days: 7
 
       - name: Upload spec metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: spec-metadata
           path: specs/original/.spec_metadata.json
@@ -251,12 +251,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Download spec metadata
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: spec-metadata
           path: specs/original/
@@ -335,13 +335,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_receipt: ${{ steps.verify_release.outputs.release_receipt }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -360,19 +362,19 @@ jobs:
           mkdir -p release/specs
 
       - name: Download reconciled specs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: reconciled-specs
           path: release/specs/
 
       - name: Download validation reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: validation-reports
           path: reports/
 
       - name: Download spec metadata
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: spec-metadata
           path: specs/original/
@@ -458,6 +460,7 @@ jobs:
           fi
 
       - name: Verify immutable GitHub release
+        id: verify_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.check-release-needed.outputs.version }}
@@ -467,7 +470,8 @@ jobs:
             --tag "v${VERSION}" \
             --expected-asset "api-specs-v${VERSION}.zip" \
             --local-asset "release/api-specs-v${VERSION}.zip" \
-            --expected-commit "${GITHUB_SHA}"
+            --expected-commit "${GITHUB_SHA}" \
+            --receipt-output "$RUNNER_TEMP/api-specs-release-receipt.json"
 
           attestation_verified=false
           for attempt in 1 2 3 4 5 6; do
@@ -486,6 +490,8 @@ jobs:
             echo "::error::GitHub release attestation did not verify"
             exit 1
           fi
+          receipt=$(jq -ce '.' "$RUNNER_TEMP/api-specs-release-receipt.json")
+          echo "release_receipt=$receipt" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         env:
@@ -533,7 +539,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
           VERSION: ${{ needs.check-release-needed.outputs.version }}
           SOURCE_REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
+          RELEASE_RECEIPT: ${{ needs.release.outputs.release_receipt }}
         run: |
           # Plain `gh api` rather than a third-party action. A
           # repository_dispatch is a single API call, so depending on an
@@ -546,13 +552,23 @@ jobs:
           # Every value crosses into the shell through env: above and is
           # referenced as a quoted variable; nothing is interpolated into this
           # body.
-          gh api "repos/f5-sales-demo/api-specs-enriched/dispatches" \
-            -f "event_type=upstream-specs-released" \
-            -f "client_payload[version]=${VERSION}" \
-            -f "client_payload[release_tag]=v${VERSION}" \
-            -f "client_payload[release_url]=${GITHUB_SERVER_URL}/${SOURCE_REPO}/releases/tag/v${VERSION}" \
-            -f "client_payload[trigger_source]=${SOURCE_REPO}" \
-            -f "client_payload[run_id]=${RUN_ID}"
+          jq -nce \
+            --arg source "$SOURCE_REPO" \
+            --argjson receipt "$RELEASE_RECEIPT" '
+              if ($receipt | keys | sort) !=
+                  (["asset_digest", "asset_name", "asset_size", "published_at", "tag_name", "version"] | sort)
+              then error("verified release receipt has an unexpected shape")
+              else {
+                event_type: "upstream-specs-released",
+                client_payload: {
+                  trigger_source: $source,
+                  release_receipt: $receipt
+                }
+              }
+              end
+            ' > "$RUNNER_TEMP/downstream-dispatch.json"
+          gh api --method POST "repos/f5-sales-demo/api-specs-enriched/dispatches" \
+            --input "$RUNNER_TEMP/downstream-dispatch.json"
 
       - name: Summary
         env:
@@ -609,7 +625,7 @@ jobs:
 
     steps:
       - name: Reconcile the failure tracker with this run
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PIPELINE_FAILED: ${{ contains(needs.*.result, 'failure') }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
@@ -723,12 +739,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -738,7 +754,7 @@ jobs:
           pip install -e .
 
       - name: Download validation reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: validation-reports
           path: reports/
@@ -811,7 +827,7 @@ jobs:
       # into a repository takeover. GITHUB_TOKEN is not a candidate either -- pushes made with
       # it do not trigger pull_request workflows, so tests.yml would never run on the PR.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           token: ${{ secrets.REPO_SYNC_TOKEN }}
 
@@ -835,7 +851,7 @@ jobs:
           mkdir -p release/specs
 
       - name: Download reconciled specs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: reconciled-specs
           path: release/specs/
@@ -844,7 +860,7 @@ jobs:
       # `include-hidden-files`, so the dot-prefixed provenance record is absent from it. The
       # artifact must carry it: the drift gate reads spec_date from here to pin info.version.
       - name: Download spec metadata
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: spec-metadata
           path: release/specs/

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import io
+import json
 import os
 import re
 import sys
@@ -87,6 +88,8 @@ def validate_release_metadata(
         raise ReleaseVerificationError("release asset is not in the uploaded state")
     if asset.get("content_type") != "application/zip":
         raise ReleaseVerificationError("release asset content type is not application/zip")
+    if type(asset.get("size")) is not int or asset["size"] <= 0:
+        raise ReleaseVerificationError("release asset size is not a positive integer")
 
     digest = asset.get("digest")
     if not isinstance(digest, str) or SHA256_DIGEST.fullmatch(digest) is None:
@@ -101,6 +104,21 @@ def validate_release_metadata(
         raise ReleaseVerificationError("release asset download URL does not match the release")
 
     return asset
+
+
+def release_receipt(release: dict[str, Any], asset: dict[str, Any]) -> dict[str, Any]:
+    """Return the exact six-field immutable identity consumed downstream."""
+    tag = release["tag_name"]
+    if not isinstance(tag, str) or not tag.startswith("v") or len(tag) == 1:
+        raise ReleaseVerificationError("release tag cannot form a downstream version")
+    return {
+        "version": tag.removeprefix("v"),
+        "tag_name": tag,
+        "published_at": release["published_at"],
+        "asset_name": asset["name"],
+        "asset_size": asset["size"],
+        "asset_digest": asset["digest"],
+    }
 
 
 def validate_tag_ref(tag_ref: dict[str, Any], tag: str, expected_commit: str) -> None:
@@ -183,6 +201,7 @@ def verify_published_release(
     *,
     token: str | None = None,
     retry: ReleaseVerificationRetry | None = None,
+    receipt_output: Path | None = None,
 ) -> str:
     """Poll until tag, release metadata, and public bytes satisfy one identity."""
     retry_policy = retry or ReleaseVerificationRetry()
@@ -219,7 +238,21 @@ def verify_published_release(
                 raise ReleaseVerificationError(
                     f"release asset download failed with HTTP {download.status_code}"
                 ) from error
+            if len(download.content) != asset["size"]:
+                raise ReleaseVerificationError(
+                    "downloaded asset size does not match GitHub release metadata"
+                )
             verify_asset_bytes(download.content, expected_digest)
+            if receipt_output is not None:
+                try:
+                    receipt_output.parent.mkdir(parents=True, exist_ok=True)
+                    receipt_output.write_text(
+                        json.dumps(release_receipt(release, asset), indent=2) + "\n"
+                    )
+                except OSError as error:
+                    raise ReleaseVerificationError(
+                        "verified release receipt could not be written"
+                    ) from error
             return expected_digest
         except (ReleaseVerificationError, requests.RequestException) as error:
             last_error = (
@@ -243,6 +276,11 @@ def main() -> int:
     parser.add_argument("--expected-asset", required=True, help="Exact ZIP asset name")
     parser.add_argument("--local-asset", type=Path, required=True, help="Locally built ZIP")
     parser.add_argument("--expected-commit", required=True, help="Exact source commit SHA")
+    parser.add_argument(
+        "--receipt-output",
+        type=Path,
+        help="Write the verified six-field downstream receipt to this path",
+    )
     parser.add_argument("--attempts", type=int, default=6)
     parser.add_argument("--interval-seconds", type=float, default=5.0)
     args = parser.parse_args()
@@ -261,6 +299,7 @@ def main() -> int:
                 attempts=args.attempts,
                 interval_seconds=args.interval_seconds,
             ),
+            receipt_output=args.receipt_output,
         )
     except (ReleaseVerificationError, ValueError) as error:
         print(f"Release verification failed: {error}", file=sys.stderr)

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -1,5 +1,6 @@
 """Structural guards for immutable release publication."""
 
+import re
 from pathlib import Path
 
 import yaml
@@ -41,6 +42,7 @@ def test_release_is_verified_after_publication():
     assert '--expected-asset "api-specs-v${VERSION}.zip"' in command
     assert '--local-asset "release/api-specs-v${VERSION}.zip"' in command
     assert '--expected-commit "${GITHUB_SHA}"' in command
+    assert '--receipt-output "$RUNNER_TEMP/api-specs-release-receipt.json"' in command
     assert 'gh release verify "v${VERSION}"' in command
     assert 'gh release verify-asset "v${VERSION}"' in command
     assert "attestation_verified" in command
@@ -51,6 +53,28 @@ def test_downstream_dispatch_requires_the_verified_release_job_to_succeed():
 
     assert "release" in notify["needs"]
     assert "needs.release.result == 'success'" in notify["if"]
+
+    release = _jobs()["release"]
+    assert release["outputs"]["release_receipt"] == (
+        "${{ steps.verify_release.outputs.release_receipt }}"
+    )
+    dispatch = next(
+        step
+        for step in notify["steps"]
+        if step["name"] == "Dispatch upstream-specs-released to api-specs-enriched"
+    )
+    assert dispatch["env"]["RELEASE_RECEIPT"] == "${{ needs.release.outputs.release_receipt }}"
+    command = dispatch["run"]
+    assert '--argjson receipt "$RELEASE_RECEIPT"' in command
+    assert "release_receipt: $receipt" in command
+    assert '--input "$RUNNER_TEMP/downstream-dispatch.json"' in command
+    for legacy in (
+        "client_payload[version]",
+        "client_payload[release_tag]",
+        "client_payload[release_url]",
+        "client_payload[run_id]",
+    ):
+        assert legacy not in command
 
 
 def test_live_validation_cannot_fall_back_or_ignore_failure():
@@ -84,3 +108,10 @@ def test_failure_tracker_cannot_close_when_publication_recovery_was_skipped():
 
     assert "publicationRecoverySkipped" in script
     assert "keeping the tracker open" in script
+
+
+def test_every_direct_action_in_release_workflow_is_commit_pinned():
+    action_refs = re.findall(r"^\s*uses:\s+([^\s@]+)@([^\s#]+)", WORKFLOW.read_text(), re.MULTILINE)
+    assert action_refs
+    for action, ref in action_refs:
+        assert re.fullmatch(r"[0-9a-f]{40}", ref), f"{action}@{ref} is mutable"

--- a/tests/test_verify_release.py
+++ b/tests/test_verify_release.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 import zipfile
 from collections.abc import Callable
 from typing import Any
@@ -62,6 +63,7 @@ def _release(**overrides):
                 "name": ASSET_NAME,
                 "state": "uploaded",
                 "content_type": "application/zip",
+                "size": len(ASSET_BYTES),
                 "digest": ASSET_DIGEST,
                 "browser_download_url": (
                     f"https://github.com/{REPOSITORY}/releases/download/{TAG}/{ASSET_NAME}"
@@ -117,6 +119,7 @@ def test_rejects_any_asset_count_other_than_one(assets):
         ({"name": "wrong.zip"}, "asset name"),
         ({"state": "new"}, "uploaded"),
         ({"content_type": "application/octet-stream"}, "content type"),
+        ({"size": 0}, "size"),
         ({"digest": None}, "SHA-256 digest"),
         ({"digest": "sha256:not-a-digest"}, "SHA-256 digest"),
         ({"browser_download_url": "https://example.com/wrong.zip"}, "download URL"),
@@ -239,6 +242,73 @@ def test_network_verification_retries_the_complete_contract_after_download_failu
 
     assert digest == ASSET_DIGEST
     assert sleeps == [0.25]
+
+
+def test_verified_download_writes_exact_downstream_receipt(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        _get_sequence(
+            [
+                _Response(payload=_tag_ref()),
+                _Response(payload=_release()),
+                _Response(content=ASSET_BYTES),
+            ]
+        ),
+    )
+    output = tmp_path / "receipt.json"
+
+    verify_published_release(
+        REPOSITORY,
+        TAG,
+        ASSET_NAME,
+        ASSET_DIGEST,
+        EXPECTED_COMMIT,
+        retry=ReleaseVerificationRetry(attempts=1, interval_seconds=0),
+        receipt_output=output,
+    )
+
+    receipt = json.loads(output.read_text())
+    assert receipt == {
+        "version": TAG.removeprefix("v"),
+        "tag_name": TAG,
+        "published_at": "2026-08-01T12:00:00Z",
+        "asset_name": ASSET_NAME,
+        "asset_size": len(ASSET_BYTES),
+        "asset_digest": ASSET_DIGEST,
+    }
+
+
+def test_verified_download_rejects_release_metadata_size_that_does_not_match_bytes(
+    monkeypatch, tmp_path
+):
+    release = _release()
+    release["assets"][0]["size"] = len(ASSET_BYTES) + 1
+    monkeypatch.setattr(
+        requests,
+        "get",
+        _get_sequence(
+            [
+                _Response(payload=_tag_ref()),
+                _Response(payload=release),
+                _Response(content=ASSET_BYTES),
+            ]
+        ),
+    )
+    output = tmp_path / "receipt.json"
+
+    with pytest.raises(ReleaseVerificationError, match="size"):
+        verify_published_release(
+            REPOSITORY,
+            TAG,
+            ASSET_NAME,
+            ASSET_DIGEST,
+            EXPECTED_COMMIT,
+            retry=ReleaseVerificationRetry(attempts=1, interval_seconds=0),
+            receipt_output=output,
+        )
+
+    assert not output.exists()
 
 
 def test_network_verification_fails_closed_after_bounded_retries(monkeypatch):


### PR DESCRIPTION
## Outcome

The correction layer now emits and dispatches the exact immutable release identity verified at publication. The downstream payload contains only `trigger_source` and the nested six-field `release_receipt`; the legacy flat release fields are removed.

The receipt is written only after the exact tag/commit, final immutable release, sole ZIP asset, local and remote SHA-256, downloaded byte size, and ZIP integrity all pass. Direct actions in the release workflow are commit-pinned.

## Verification

- Fresh current-main branch: 35 focused tests passed.
- Independent complete suite on the byte-identical patch: 374 passed, 1 opt-in live test skipped.
- Ruff, format, MyPy, Actionlint, Yamllint, Zizmor, exact jq payload construction, and `git diff --check` passed.
- Negative regression proves a metadata/download size mismatch produces no receipt.

Closes #852