### PR TITLE
docs: resolve Markdown lint violations

### DIFF
--- a/docs/01-validation-report.mdx
+++ b/docs/01-validation-report.mdx
@@ -3,13 +3,11 @@ title: Validation Report
 description: F5 XC API spec validation and fix report
 ---
 
-# F5 XC API Spec Fixes Applied
-
 Validated and reconciled F5 Distributed Cloud OpenAPI specifications.
 
 This project validates F5 XC OpenAPI specifications against the live API, identifies discrepancies, and automatically applies fixes to produce corrected spec files.
 
-*Last updated: 2026-08-02 14:30 UTC*
+Last updated: 2026-08-02 14:30 UTC
 
 ## Summary
 
@@ -24,7 +22,7 @@ All specs match live API behavior. No modifications were applied.
 ## Fix Strategies
 
 | Strategy | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | **Relaxed** | Constraint was too strict - API accepts values the spec rejected |
 | **Tightened** | Constraint was too loose - API rejects values the spec accepted |
 | **Added** | Missing constraint discovered through API testing |

--- a/docs/en/01-validation-report.mdx
+++ b/docs/en/01-validation-report.mdx
@@ -3,13 +3,11 @@ title: Validation Report
 description: F5 XC API spec validation and fix report
 ---
 
-# F5 XC API Spec Fixes Applied
-
 Validated and reconciled F5 Distributed Cloud OpenAPI specifications.
 
 This project validates F5 XC OpenAPI specifications against the live API, identifies discrepancies, and automatically applies fixes to produce corrected spec files.
 
-*Last updated: 2026-06-07 08:58 UTC*
+Last updated: 2026-06-07 08:58 UTC
 
 ## Summary
 
@@ -24,7 +22,7 @@ All specs match live API behavior. No modifications were applied.
 ## Fix Strategies
 
 | Strategy | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | **Relaxed** | Constraint was too strict - API accepts values the spec rejected |
 | **Tightened** | Constraint was too loose - API rejects values the spec accepted |
 | **Added** | Missing constraint discovered through API testing |

--- a/docs/en/03-fixes-applied.mdx
+++ b/docs/en/03-fixes-applied.mdx
@@ -10,7 +10,7 @@ The reconciler (`scripts/reconcile.py`) applies four categories of fixes to upst
 These fixes adjust OpenAPI schema constraints so the spec matches what the live API actually enforces. Each fix is driven by a `Discrepancy` object produced during [validation](/api-specs/en/02-pipeline/#2-validate).
 
 | Strategy | Trigger | What It Does | Contract Change |
-|----------|---------|--------------|-----------------|
+| ---------- | --------- | -------------- | ----------------- |
 | **Relax** | `SPEC_STRICTER` | Spec rejects values the API accepts. Lowers `minLength`/`minimum`, raises `maxLength`/`maximum`, adds missing enum values. | Yes -- widens accepted values |
 | **Tighten** | `SPEC_LOOSER` | Spec accepts values the API rejects. Raises `minLength`/`minimum`, lowers `maxLength`/`maximum`, restricts enums to observed values. | Yes -- narrows accepted values |
 | **Add** | `MISSING_CONSTRAINT` | API enforces a constraint not documented in the spec. Adds the constraint to the schema. | Yes -- adds new constraint |

--- a/docs/en/04-spectral-rules.mdx
+++ b/docs/en/04-spectral-rules.mdx
@@ -66,7 +66,7 @@ The custom `f5-path-params` function (`spectral/functions/f5-path-params.js`) co
 These rules are auto-fixed by the reconciler when violations are detected. See [Fixes Applied](/api-specs/en/03-fixes-applied/) for details on each fix.
 
 | Rule | Severity | Fix Method | Description |
-|------|----------|------------|-------------|
+| ------ | ---------- | ------------ | ------------- |
 | `oas3-api-servers` | warn | `_add_servers` | Spec must have a `servers` block |
 | `info-contact` | warn | `_add_contact` | `info` must include `contact` |
 | `operation-tags` | warn | `_add_tags` | Every operation must have at least one tag |
@@ -85,7 +85,7 @@ These rules are auto-fixed by the reconciler when violations are detected. See [
 These rules are downgraded to `info` severity because they cannot be auto-fixed meaningfully:
 
 | Rule | Severity | Description |
-|------|----------|-------------|
+| --- | --- | --- |
 | `operation-description` | info | Operations should have a description |
 | `info-description` | info | API info should have a description |
 
@@ -116,7 +116,7 @@ Scans `release/specs/` and writes `reports/spectral_gate_report.json`. Returns e
 Spectral violations are converted to `Discrepancy` objects with three subtypes:
 
 | Spectral Rule Category | DiscrepancyType | Example Rules |
-|------------------------|-----------------|---------------|
+| ------------------------ | ----------------- | --------------- |
 | Missing required element | `SPECTRAL_MISSING` | `oas3-api-servers`, `info-contact`, `operation-tags` |
 | Invalid existing element | `SPECTRAL_INVALID` | `oas3-valid-schema-example`, `no-script-tags-in-markdown` |
 | Dead code | `SPECTRAL_UNUSED` | `oas3-unused-component` |

--- a/docs/en/05-configuration.mdx
+++ b/docs/en/05-configuration.mdx
@@ -16,7 +16,7 @@ api:
 ```
 
 | Field | Description |
-|-------|-------------|
+| --- | --- |
 | `timeout` | HTTP request timeout in seconds. |
 | `retries` | Number of retry attempts on failure. |
 
@@ -30,6 +30,7 @@ export F5XC_API_URL="https://example-tenant.console.ves.volterra.io"
 export F5XC_NAMESPACE="example-namespace"
 export F5XC_API_TOKEN="your-api-token"
 ```
+
 :::
 
 ### Download Settings
@@ -42,7 +43,7 @@ download:
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `url` | URL of the official F5 XC OpenAPI spec bundle (ZIP). |
 | `output_dir` | Where extracted specs are stored. |
 | `etag_cache` | File that stores the HTTP ETag for conditional downloads. |
@@ -71,7 +72,7 @@ validation_categories:
 ```
 
 | Category | Keywords |
-|----------|----------|
+| ---------- | ---------- |
 | `string_length` | `minLength`, `maxLength` |
 | `pattern` | `pattern` |
 | `numeric_bounds` | `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum` |
@@ -91,7 +92,7 @@ schemathesis:
 ```
 
 | Field | Description |
-|-------|-------------|
+| --- | --- |
 | `examples_per_operation` | Exact number of generated test cases per configured operation. |
 
 Generation is derandomized and uses only Hypothesis's generation phase, so an
@@ -114,7 +115,7 @@ reconciliation:
 ```
 
 | Field | Description |
-|-------|-------------|
+| --- | --- |
 | `priority` | Order of preference when multiple data sources disagree. |
 | `fix_strategies` | Maps each discrepancy type to its fix action. See [Fixes Applied](/api-specs/en/03-fixes-applied/). |
 
@@ -154,7 +155,7 @@ spectral:
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `enabled` | Toggle Spectral linting entirely. |
 | `ruleset` | Which Spectral config file to use (pipeline uses `spectral-pipeline.yaml`). |
 | `auto_fix` | Map of rule name to boolean. `true` means the reconciler will fix violations. |
@@ -188,7 +189,7 @@ release:
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `output_dir` | Directory for release artifacts. |
 | `include_changelog` | Include `CHANGELOG.md` in the release package. |
 | `include_validation_report` | Include the validation report in the release package. |
@@ -217,7 +218,7 @@ endpoints:
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `resource` | API resource name (used in URL paths). |
 | `domain_file` | Filename of the OpenAPI spec in `specs/original/`. |
 | `api_group` | API group prefix (`config`, `web`, etc.). |
@@ -230,7 +231,7 @@ endpoints:
 10 endpoints across three domains:
 
 | Endpoint | Domain | Priority |
-|----------|--------|----------|
+| ---------- | -------- | ---------- |
 | `healthcheck` | Virtual | high |
 | `origin_pool` | Virtual | high |
 | `app_firewall` | Virtual | high |

--- a/docs/en/06-contributing.mdx
+++ b/docs/en/06-contributing.mdx
@@ -76,7 +76,7 @@ make pre-commit           # Run all hooks manually
 
 ## Project Structure
 
-```
+```text
 scripts/
   download.py           # Stage 1: Fetch specs from F5
   validate.py           # Stage 2: Live API testing
@@ -112,6 +112,7 @@ To add a new Spectral auto-fix to the reconciler:
 1. **Add the rule** to `.spectral.yaml` with the desired severity.
 
 2. **Enable auto-fix** in `config/validation.yaml` under `spectral.auto_fix`:
+
    ```yaml
    spectral:
      auto_fix:
@@ -119,6 +120,7 @@ To add a new Spectral auto-fix to the reconciler:
    ```
 
 3. **Add the fixer method** to `SpecReconciler` in `scripts/reconcile.py`:
+
    ```python
    def _fix_your_rule(self, spec: dict, discrepancy: Discrepancy) -> dict | None:
        """Fix description."""
@@ -128,6 +130,7 @@ To add a new Spectral auto-fix to the reconciler:
    ```
 
 4. **Register it** in the `_apply_spectral_fix` dispatcher:
+
    ```python
    spectral_fixers = {
        # ... existing fixers ...
@@ -144,6 +147,7 @@ To add a custom Spectral rule with a JavaScript function:
 1. Create the function in `spectral/functions/your-rule.js`. Export a default function that receives `(targetVal, options, context)` and returns an array of `{message, path}` objects.
 
 2. Register it in `spectral-pipeline.yaml`:
+
    ```yaml
    functions:
      - f5-path-params

--- a/docs/en/spelling-audit.mdx
+++ b/docs/en/spelling-audit.mdx
@@ -3,8 +3,6 @@ title: Spelling Audit Report
 description: Verified spelling errors in the F5 Distributed Cloud OpenAPI specifications
 ---
 
-# Spelling Audit Report
-
 **Date:** 2026-06-09
 **Verified against:** `nferreira.staging.volterra.us` (live API)
 **Specs audited:** 268 OpenAPI JSON files (`release/specs/`)
@@ -12,7 +10,7 @@ description: Verified spelling errors in the F5 Distributed Cloud OpenAPI specif
 ## Summary
 
 | Category | Count | Status |
-|----------|-------|--------|
+| ---------- | ------- | -------- |
 | Text field typos (description/summary/title) | 109 unique errors across 761 fields | Auto-corrected by `fix_spelling` transform |
 | Property name typos — fixable | 1 | Auto-corrected by `fix_property_names` transform |
 | Property name typos — upstream platform | 5 | Spec correctly reflects the live API |
@@ -102,7 +100,7 @@ property names. They are automatically corrected by the `fix_spelling` transform
 ### High frequency (10+ occurrences)
 
 | Misspelling | Correction | Occurrences |
-|-------------|-----------|-------------|
+| ------------- | ----------- | ------------- |
 | `referrred` | referred | 186 |
 | `Validtion` | Validation | 173 |
 | `succeded` | succeeded | 173 |
@@ -114,7 +112,7 @@ property names. They are automatically corrected by the `fix_spelling` transform
 ### Medium frequency (2–9 occurrences)
 
 | Misspelling | Correction |
-|-------------|-----------|
+| ------------- | ----------- |
 | `positve` | positive |
 | `Refernce` | Reference |
 | `verfication` | verification |
@@ -158,14 +156,14 @@ The complete dictionary of 109 corrections is maintained in
 ### Existing transforms
 
 | Transform | Config | What it fixes |
-|-----------|--------|---------------|
+| --- | --- | --- |
 | `fix_spelling` | `config/spelling_corrections.yaml` | Text field typos (description/summary/title) |
 | `fix_property_names` | `config/property_name_corrections.yaml` | Verified property key renames |
 
 ### CI targets
 
 | Command | Purpose |
-|---------|---------|
+| --------- | --------- |
 | `make spell-check-specs` | Run codespell on spec text fields and property names |
 | `make verify-property-names` | Probe live API to verify property name corrections |
 | `make transform` | Apply all corrections (text fields + verified property renames) |


### PR DESCRIPTION
## Summary

- normalize Markdown tables and structural formatting for the newly enforced fleet rules
- tag schematic and command fences where the same touched files exposed untagged blocks
- keep translated content untouched for its planned final regeneration

Closes #863

## Testing

- markdownlint-cli 0.49.1 and governed prose gate on every changed Markdown/MDX file
- shellcheck and shfmt over every tracked shell script
- `git diff --check origin/main...HEAD`
