### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,8 +1,8 @@
 {
   "spec_date": "2026.07.30",
   "spec_timestamp": "2026-07-30T15:32:53+00:00",
-  "download_date": "2026.08.03",
-  "download_timestamp": "2026-08-03T15:04:50.107258+00:00",
+  "download_date": "2026.08.08",
+  "download_timestamp": "2026-08-08T03:47:44.378651+00:00",
   "etag": "W/\"33e92e-19fb3a83488\"",
   "last_modified": "Thu, 30 Jul 2026 15:32:53 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.