### PR TITLE
feat: enforce workflow security boundaries, upgrade to Node 24, and extend contract tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -28,7 +28,7 @@ permissions:
 
 env:
   PYTHON_VERSION: '3.11.13'
-  NODE_VERSION: '20.19.5'
+  NODE_VERSION: '24.19.0'
   UV_VERSION: '0.12.1'
 
 concurrency:
@@ -39,6 +39,7 @@ jobs:
   validate:
     name: Validate Specs
     runs-on: ubuntu-latest
+    environment: f5xc-live-validation
     permissions:
       contents: read # Checks out the exact source and tag history used as validation inputs.
       issues: write # Synchronizes measured live discrepancies to their tracker issues.
@@ -48,18 +49,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Need full history for tags
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js (for Spectral)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           # Now that a lockfile exists, setup-node can key the npm cache off it.
@@ -93,7 +94,7 @@ jobs:
 
       - name: Get previous ETag from cache
         id: prev_etag
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .etag_cache
           key: etag-${{ github.sha }}
@@ -195,7 +196,7 @@ jobs:
 
       - name: Upload issue mapping artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: issue-mapping
           path: reports/issue_mapping.json
@@ -212,21 +213,21 @@ jobs:
         # its report is the only place the offending rule and file are
         # recorded in full.
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: validation-reports
           path: reports/
           retention-days: 30
 
       - name: Upload reconciled specs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reconciled-specs
           path: release/specs/
           retention-days: 7
 
       - name: Upload spec metadata
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spec-metadata
           path: specs/original/.spec_metadata.json
@@ -245,13 +246,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -326,12 +327,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -374,7 +375,7 @@ jobs:
             --build-timestamp "${BUILD_TIMESTAMP}"
 
       - name: Upload release candidate
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate-${{ matrix.candidate }}
           path: release/candidate/api-specs-v${{ needs.release-metadata.outputs.version }}.zip
@@ -401,13 +402,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -462,7 +463,7 @@ jobs:
             --recovery-directory release
 
       - name: Upload semantic release decision
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: semantic-release-decision
           path: reports/semantic-release-decision.json
@@ -470,7 +471,7 @@ jobs:
 
       - name: Upload release candidate
         if: steps.check.outputs.should_publish == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-candidate
           path: release/${{ steps.check.outputs.release_asset }}
@@ -482,6 +483,7 @@ jobs:
     needs: [validate, check-release-needed]
     if: needs.check-release-needed.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    environment: repository-settings
     permissions:
       contents: write # Creates the exact tag and immutable GitHub release asset.
     outputs:
@@ -489,12 +491,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -624,6 +626,7 @@ jobs:
     # release publication and downstream delivery have separate permissions.
     if: needs.release.result == 'success'
     runs-on: ubuntu-latest
+    environment: api-specs-enriched-release-delivery
     # The cross-repo dispatch authenticates with a PAT because a repository's
     # own GITHUB_TOKEN cannot dispatch elsewhere. GITHUB_TOKEN writes only the
     # exact-receipt deployment acknowledgement in this source repository.
@@ -633,12 +636,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -878,26 +881,42 @@ jobs:
     name: Update Documentation
     needs: [validate]
     runs-on: ubuntu-latest
+    environment: api-specs-publication
     permissions:
       contents: write # Pushes the generated documentation branch.
       pull-requests: write # Opens and enables auto-merge for the generated documentation PR.
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          token: ${{ secrets.REPO_SYNC_TOKEN }}
           persist-credentials: false
 
+      - name: Fail fast if the sync token is absent
+        env:
+          SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+        run: |
+          if [ -z "${SYNC_TOKEN}" ]; then
+            echo "::error::REPO_SYNC_TOKEN is not set. Refusing to fall back."
+            exit 1
+          fi
+
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Sync locked environment
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .
+          uv sync --frozen
 
       - name: Download validation reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -907,13 +926,13 @@ jobs:
 
       - name: Generate documentation
         run: |
-          python scripts/generate_docs.py \
+          uv run --frozen python scripts/generate_docs.py \
             --reconciliation-report reports/reconciliation_report.json \
             --output docs/en/01-validation-report.mdx
 
       - name: Commit and PR if changed
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -965,6 +984,7 @@ jobs:
     name: Publish Regenerated Specs
     needs: [validate]
     runs-on: ubuntu-latest
+    environment: api-specs-publication
     permissions:
       contents: write # Pushes the regenerated specification artifact branch.
       pull-requests: write # Opens and enables auto-merge for the artifact publication PR.
@@ -981,7 +1001,7 @@ jobs:
       # into a repository takeover. GITHUB_TOKEN is not a candidate either -- pushes made with
       # it do not trigger pull_request workflows, so tests.yml would never run on the PR.
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_SYNC_TOKEN }}
           persist-credentials: false

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -286,7 +286,7 @@ def test_dispatch_success_precedes_durable_exact_receipt_acknowledgement():
 def test_release_builder_toolchain_is_exact_locked_and_reproduced_in_fresh_environments():
     workflow = yaml.safe_load(WORKFLOW.read_text())
     assert workflow["env"]["PYTHON_VERSION"] == "3.11.13"
-    assert workflow["env"]["NODE_VERSION"] == "20.19.5"
+    assert workflow["env"]["NODE_VERSION"] == "24.19.0"
     assert LOCKFILE.is_file()
     assert "uv.lock" in workflow[True]["push"]["paths"]
 
@@ -444,3 +444,99 @@ def test_release_workflow_security_and_push_contract():
         assert "trap " in run_script and "rm -f" in run_script, (
             f"Askpass helper must use trap for cleanup in job {job_name}"
         )
+
+
+def test_release_workflow_explicit_environments():
+    """Verify that jobs in validate-and-release.yml are explicitly mapped to their correct security environments."""
+    jobs = _jobs()
+    assert jobs["validate"]["environment"] == "f5xc-live-validation"
+    assert jobs["release"]["environment"] == "repository-settings"
+    assert jobs["notify-downstream"]["environment"] == "api-specs-enriched-release-delivery"
+    assert jobs["update-docs"]["environment"] == "api-specs-publication"
+    assert jobs["commit-release-specs"]["environment"] == "api-specs-publication"
+
+
+def test_narrower_token_selection_and_no_admin_token():
+    """Verify that secrets.REPO_ADMIN_TOKEN is eliminated and REPO_SYNC_TOKEN is used with a fail-fast checker."""
+    workflow_text = WORKFLOW.read_text()
+    assert "secrets.REPO_ADMIN_TOKEN" not in workflow_text, (
+        "secrets.REPO_ADMIN_TOKEN must be completely eliminated"
+    )
+
+    jobs = _jobs()
+    for job_name in ("update-docs", "commit-release-specs"):
+        job = jobs[job_name]
+        steps = job["steps"]
+
+        # Check checkout step token
+        checkout_step = next(
+            step for step in steps if step.get("uses", "").startswith("actions/checkout")
+        )
+        assert checkout_step["with"]["token"] == "${{ secrets.REPO_SYNC_TOKEN }}"
+
+        # Check fail-fast helper checking REPO_SYNC_TOKEN liveness
+        fail_fast_step = next(step for step in steps if "Fail fast if" in step.get("name", ""))
+        assert "REPO_SYNC_TOKEN" in fail_fast_step["env"]["SYNC_TOKEN"]
+        assert 'if [ -z "${SYNC_TOKEN}" ]' in fail_fast_step["run"]
+
+        # Check commit/push step token
+        commit_step = next(
+            step
+            for step in steps
+            if "Commit and PR" in step.get("name", "") or "Open a PR if" in step.get("name", "")
+        )
+        assert commit_step["env"]["GH_TOKEN"] == "${{ secrets.REPO_SYNC_TOKEN }}"
+
+
+def test_deterministic_uv_in_documentation_setup():
+    """Verify that update-docs uses deterministic uv commands and no raw pip."""
+    jobs = _jobs()
+    steps = jobs["update-docs"]["steps"]
+
+    # Assert setup-uv and uv sync --frozen are used
+    assert any(step.get("uses", "").startswith("astral-sh/setup-uv") for step in steps)
+    assert any("uv sync --frozen" in step.get("run", "") for step in steps)
+    assert not any("pip install" in step.get("run", "") for step in steps)
+
+    # Assert generate step uses uv run --frozen
+    generate_step = next(step for step in steps if step.get("name") == "Generate documentation")
+    assert "uv run --frozen python" in generate_step["run"]
+
+
+def test_tests_workflow_checkout_persist_credentials():
+    """Verify that all actions/checkout steps in tests.yml have persist-credentials explicitly set to False."""
+    test_wf = yaml.safe_load(TEST_WORKFLOW.read_text())
+    found_checkout = False
+    for job_name, job_def in test_wf["jobs"].items():
+        if "steps" in job_def:
+            for step in job_def["steps"]:
+                if step.get("uses", "").startswith("actions/checkout"):
+                    found_checkout = True
+                    assert "persist-credentials" in step.get("with", {}), (
+                        f"persist-credentials parameter is missing in tests.yml job {job_name}"
+                    )
+                    assert step["with"]["persist-credentials"] is False, (
+                        f"persist-credentials must be boolean False in tests.yml job {job_name}"
+                    )
+    assert found_checkout, "Expected to find actions/checkout in tests.yml"
+
+
+def test_node24_action_hashes_are_strictly_enforced():
+    """Verify that all checkouts, setup-python, setup-node, cache, and upload-artifact steps in release and test workflows use specific Node 24 hashes."""
+    expected_hashes = {
+        "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/setup-python": "5fda3b95a4ea91299a34e894583c3862153e4b97",
+        "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
+        "actions/cache": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+        "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    }
+
+    for workflow_path in (WORKFLOW, TEST_WORKFLOW):
+        content = workflow_path.read_text()
+        action_refs = re.findall(r"^\s*uses:\s+([^\s@]+)@([^\s#\n\s]+)", content, re.MULTILINE)
+        for action, ref in action_refs:
+            if action in expected_hashes:
+                assert ref == expected_hashes[action], (
+                    f"In {workflow_path.name}, action {action} is pinned to {ref}, "
+                    f"expected Node 24 hash {expected_hashes[action]}"
+                )


### PR DESCRIPTION
Enforce strict security boundaries, upgrade to Node 24 across release and test workflows, and extend comprehensive contract tests to prevent regressions.

- Bound validate, release, notify-downstream, update-docs, and commit-release-specs to explicit security environments
- Pin all action versions to Node 24 hashes (Checkout v7.0.1, Setup-node v7.0.0, Setup-python v7.0.0, Cache v6.1.0, Upload-artifact v7.0.1)
- Lock global node runtime to 24.19.0
- Introduce fail-fast token assertion and narrow secret access to REPO_SYNC_TOKEN (eliminating REPO_ADMIN_TOKEN)
- Transition update-docs job to setup-uv and uv run for deterministic Python dependency management
- Set checkout persist-credentials: false in tests.yml
- Add structural contract tests to prevent regressions on action hashes, token selection, environments, and persist-credentials

Closes #967
Closes #884
Closes #847