### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -2,7 +2,7 @@
   "spec_date": "2026.08.11",
   "spec_timestamp": "2026-08-11T20:41:57+00:00",
   "download_date": "2026.08.12",
-  "download_timestamp": "2026-08-12T07:24:30.390587+00:00",
+  "download_timestamp": "2026-08-12T14:50:38.443834+00:00",
   "etag": "W/\"33e92e-19ff28f7a08\"",
   "last_modified": "Tue, 11 Aug 2026 20:41:57 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.