### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,8 +1,8 @@
 {
   "spec_date": "2026.08.12",
   "spec_timestamp": "2026-08-12T19:38:17+00:00",
-  "download_date": "2026.08.13",
-  "download_timestamp": "2026-08-13T07:26:34.205256+00:00",
+  "download_date": "2026.08.14",
+  "download_timestamp": "2026-08-14T07:22:17.876382+00:00",
   "etag": "W/\"33e92e-19ff77b8c28\"",
   "last_modified": "Wed, 12 Aug 2026 19:38:17 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.