### PR TITLE
fix(lint): allow managed validator CLI filename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ ignore = [
     "B007",     # Loop control variable not used (intentional)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"scripts/workflow-security-validator.py" = ["N999"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
## Summary

- allow Ruff `N999` only for the centrally managed `scripts/workflow-security-validator.py` CLI filename
- retain naming enforcement for every other Python module
- unblock managed-file PR #1030

## Verification

- failing reproduction before the change: `ruff check --stdin-filename scripts/workflow-security-validator.py -`
- passing reproduction after the change
- control filename still fails `N999`
- `ruff check .`
- `git diff --check`
- exact-HEAD Antigravity semantic review passed (repository-wide PII preflight separately reported legacy generated-content findings; no finding is in this diff)
- GitHub Python suite on managed head #1030 passed

Closes #1031