### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -141,7 +141,61 @@
       }
     },
     "f5-sales-demo/xcsh": {
+      ".github/workflows/api-spec-update.yml": {
+        "update-api-specs": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release dispatch uses the hosted delivery environment"
+        }
+      },
       ".github/workflows/ci.yml": {
+        "check": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "CI validation uses the hosted Bun toolchain"
+        },
+        "setup-zig": {
+          "runs_on": "matrix",
+          "reason": "Zig setup validates hosted Linux, macOS, and Windows"
+        },
+        "native": {
+          "runs_on": "matrix",
+          "reason": "native builds require hosted platform-specific toolchains"
+        },
+        "test": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "test provisioning installs an ephemeral hosted toolchain"
+        },
+        "install_methods": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "installation tests require ephemeral package provisioning"
+        },
+        "invalidate-stale-release-prs": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release PR maintenance uses the hosted GitHub environment"
+        },
+        "auto-release": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release planning uses the hosted GitHub environment"
+        },
+        "build-release": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release packaging uses the hosted Linux toolchain"
+        },
+        "create-release": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release publication uses the hosted GitHub environment"
+        },
+        "update-homebrew": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "Homebrew formula updates use the hosted release environment"
+        },
+        "publish-npm": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "npm publication uses the hosted release environment"
+        },
+        "verify-npm-install": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "npm installation verification uses the hosted environment"
+        },
         "build-sign-macos": {
           "runs_on": "matrix",
           "reason": "Apple signing and notarization require macOS"
@@ -149,6 +203,60 @@
         "verify-homebrew-install": {
           "runs_on": "macos-14",
           "reason": "Homebrew release verification requires macOS"
+        }
+      },
+      ".github/workflows/console-catalog-drift.yml": {
+        "drift-guard": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "catalog reconciliation uses the hosted GitHub environment"
+        }
+      },
+      ".github/workflows/console-catalog-update.yml": {
+        "update-console-catalog": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "catalog publishing uses the hosted GitHub environment"
+        }
+      },
+      ".github/workflows/container.yml": {
+        "container-build": {
+          "runs_on": "matrix",
+          "reason": "container builds require hosted native amd64 and arm64 runners"
+        },
+        "podman-uat-harness": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "Podman harness runs in an ephemeral hosted environment"
+        },
+        "container-test": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "container aggregation runs in the hosted test environment"
+        },
+        "publish-ghcr": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "container publication uses the hosted Docker environment"
+        }
+      },
+      ".github/workflows/deploy-office-pane.yml": {
+        "deploy": {
+          "runs_on": "ubuntu-latest",
+          "reason": "office-pane deployment uses hosted release credentials"
+        }
+      },
+      ".github/workflows/pii-guard.yml": {
+        "pii-guard": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "PII enforcement runs in an isolated hosted environment"
+        }
+      },
+      ".github/workflows/release-reconcile.yml": {
+        "reconcile": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "release reconciliation uses hosted registry access"
+        }
+      },
+      ".github/workflows/tag-on-version-bump.yml": {
+        "tag": {
+          "runs_on": "ubuntu-22.04",
+          "reason": "immutable release tagging uses hosted GitHub credentials"
         }
       },
       ".github/workflows/test-codesign.yml": {


### PR DESCRIPTION
Closes #1040

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json