### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -62,6 +62,14 @@
     }
   },
   "hosted_exceptions": {
+    "f5-sales-demo/api-specs-enriched": {
+      ".github/workflows/workflow-security-audit.yml": {
+        "workflow-security-audit": {
+          "runs_on": "ubuntu-latest",
+          "reason": "read-only pull request workflow security audit"
+        }
+      }
+    },
     "f5-sales-demo/devcontainer": {
       ".github/workflows/docker-publish.yml": {
         "build-arm64": {


### PR DESCRIPTION
Closes #1042

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json