### PR TITLE
fix(ci): make release validation offline-only

### DIFF
--- a/.github/workflows/validate-and-release.yml
+++ b/.github/workflows/validate-and-release.yml
@@ -39,10 +39,8 @@ jobs:
   validate:
     name: Validate Specs
     runs-on: [self-hosted, Linux, X64, api-specs, ubuntu-24.04]
-    environment: f5xc-live-validation
     permissions:
       contents: read # Checks out the exact source and tag history used as validation inputs.
-      issues: write # Synchronizes measured live discrepancies to their tracker issues.
     outputs:
       specs_changed: ${{ steps.check_specs.outputs.changed }}
       specs_etag: ${{ steps.check_specs.outputs.etag }}
@@ -138,16 +136,11 @@ jobs:
           uv run --frozen python -m scripts.transform
           echo "Transformed specs written to specs/transformed/"
 
-      - name: Validate specs (live)
-        env:
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
-          F5XC_NAMESPACE: ${{ secrets.F5XC_NAMESPACE }}
+      - name: Write offline validation report
         run: |
-          : "${F5XC_API_URL:?F5XC_API_URL is required for live validation}"
-          : "${F5XC_API_TOKEN:?F5XC_API_TOKEN is required for live validation}"
-          : "${F5XC_NAMESPACE:?F5XC_NAMESPACE is required for live validation}"
-          uv run --frozen python -m scripts.validate --allow-discrepancies
+          uv run --frozen python -m scripts.offline_validation_report \
+            --spec-dir specs/transformed \
+            --output reports/validation_report.json
 
       - name: Run Spectral OAS3 linting
         run: |
@@ -162,45 +155,6 @@ jobs:
             --report reports/validation_report.json \
             --reconciliation-report-out reports/reconciliation_report.json
           echo "Fix report saved to reports/reconciliation_report.json"
-
-      - name: Sync discrepancies to GitHub issues
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          uv run --frozen python -m scripts.issue_sync \
-            --report reports/validation_report.json \
-            --mapping-out reports/issue_mapping.json \
-            --config config/issue_sync.yaml \
-            --run-url "$RUN_URL"
-
-      - name: Sync discrepancies (dry-run on PR)
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          F5XC_API_URL: ${{ secrets.F5XC_API_URL }}
-          F5XC_API_TOKEN: ${{ secrets.F5XC_API_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          uv run --frozen python -m scripts.issue_sync \
-            --report reports/validation_report.json \
-            --mapping-out reports/issue_mapping.json \
-            --config config/issue_sync.yaml \
-            --dry-run \
-            --run-url "$RUN_URL"
-
-      - name: Upload issue mapping artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: issue-mapping
-          path: reports/issue_mapping.json
-          retention-days: 30
 
       - name: Spectral quality gate
         run: |

--- a/scripts/offline_validation_report.py
+++ b/scripts/offline_validation_report.py
@@ -1,0 +1,61 @@
+"""Write the deterministic validation receipt used by offline release CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def count_operations(spec_dir: Path) -> int:
+    """Count OpenAPI operations from transformed JSON documents without network access."""
+    count = 0
+    for path in sorted(spec_dir.glob("*.json")):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        paths = document.get("paths", {})
+        if not isinstance(paths, dict):
+            raise ValueError(f"{path} paths must be an object")
+        for operations in paths.values():
+            if not isinstance(operations, dict):
+                continue
+            count += sum(
+                1
+                for method, operation in operations.items()
+                if method.lower() in {"get", "put", "post", "delete", "patch", "head", "options"}
+                and isinstance(operation, dict)
+            )
+    return count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Write an offline validation report")
+    parser.add_argument("--spec-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    endpoints = count_operations(args.spec_dir)
+    report = {
+        "summary": {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "mode": "offline",
+            "total_endpoints": endpoints,
+            "total_tests": 0,
+            "passed": 0,
+            "failed": 0,
+            "errors": 0,
+            "total_discrepancies": 0,
+            "discrepancies_by_type": {},
+            "modified_files": [],
+            "unmodified_files": [],
+        },
+        "results": [],
+        "discrepancies": [],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_offline_validation_report.py
+++ b/tests/test_offline_validation_report.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+
+from scripts.offline_validation_report import main
+
+
+def test_offline_report_records_spec_inventory_without_live_results(tmp_path):
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    (specs / "one.json").write_text('{"paths": {"/one": {"get": {}}}}')
+    (specs / "two.json").write_text('{"paths": {"/two": {"post": {}, "delete": {}}}}')
+    output = tmp_path / "reports" / "validation_report.json"
+
+    assert main(["--spec-dir", str(specs), "--output", str(output)]) == 0
+
+    report = json.loads(output.read_text())
+    assert report["summary"]["mode"] == "offline"
+    assert report["summary"]["total_endpoints"] == 3
+    assert report["summary"]["total_tests"] == 0
+    assert report["summary"]["total_discrepancies"] == 0
+    assert report["results"] == []
+    assert report["discrepancies"] == []

--- a/tests/test_release_workflow_contract.py
+++ b/tests/test_release_workflow_contract.py
@@ -204,24 +204,20 @@ def test_release_notes_render_the_measured_semantic_decision():
     assert "Upstream F5 XC specs updated" not in command
 
 
-def test_live_validation_cannot_fall_back_or_ignore_failure():
+def test_release_validation_is_offline_and_never_reads_live_f5xc_credentials():
     workflow = yaml.safe_load(WORKFLOW.read_text())
     dispatch = workflow[True]["workflow_dispatch"]
     assert "skip_live_tests" not in dispatch.get("inputs", {})
 
     validate_steps = _jobs()["validate"]["steps"]
-    assert not any(step["name"] == "Validate specs (dry run)" for step in validate_steps)
-    live = next(step for step in validate_steps if step["name"] == "Validate specs (live)")
-    command = live["run"]
-
-    assert "if" not in live
-    assert 'if [ -z "${F5XC_API_TOKEN}" ]' not in command
-    assert "--dry-run" not in command
-    assert "|| true" not in command
-    assert "${F5XC_API_TOKEN:?" in command
-    assert "${F5XC_API_URL:?" in command
-    assert "${F5XC_NAMESPACE:?" in command
-    assert live["env"]["F5XC_NAMESPACE"] == "${{ secrets.F5XC_NAMESPACE }}"
+    assert not any("live" in step.get("name", "").lower() for step in validate_steps)
+    offline = next(
+        step for step in validate_steps if step["name"] == "Write offline validation report"
+    )
+    assert "python -m scripts.offline_validation_report" in offline["run"]
+    assert "F5XC_" not in WORKFLOW.read_text()
+    assert "scripts.validate" not in WORKFLOW.read_text()
+    assert "scripts.issue_sync" not in WORKFLOW.read_text()
 
 
 def test_failure_tracker_tracks_pipeline_health_without_inferring_delivery_state():
@@ -367,16 +363,17 @@ def test_python_test_workflow_uses_the_same_locked_toolchain():
 
 
 def test_release_workflow_parameters_contract():
-    """Verify parameters contract such as --allow-discrepancies and --reconciliation-report-out."""
+    """Verify offline-report, reconciliation, and publication parameters."""
     workflow = yaml.safe_load(WORKFLOW.read_text())
     jobs = workflow["jobs"]
     validate = jobs["validate"]
 
-    # 1. Verify --allow-discrepancies is present in validation step
+    # 1. Verify the offline report is written from transformed specs.
     validation_step = next(
-        step for step in validate["steps"] if step.get("name") == "Validate specs (live)"
+        step for step in validate["steps"] if step.get("name") == "Write offline validation report"
     )
-    assert "--allow-discrepancies" in validation_step["run"]
+    assert "--spec-dir specs/transformed" in validation_step["run"]
+    assert "--output reports/validation_report.json" in validation_step["run"]
 
     # 2. Verify --reconciliation-report-out is present in reconcile step
     reconcile_step = next(
@@ -472,7 +469,7 @@ def test_release_workflow_security_and_push_contract():
 def test_release_workflow_explicit_environments():
     """Verify that jobs in validate-and-release.yml are explicitly mapped to their correct security environments."""
     jobs = _jobs()
-    assert jobs["validate"]["environment"] == "f5xc-live-validation"
+    assert "environment" not in jobs["validate"]
     assert jobs["release"]["environment"] == "repository-settings"
     assert jobs["notify-downstream"]["environment"] == "api-specs-enriched-release-delivery"
     assert jobs["update-docs"]["environment"] == "api-specs-publication"


### PR DESCRIPTION
## Summary

Make Validate-and-Release independent of F5 XC credentials and live API calls. The workflow now writes a deterministic offline validation report from transformed specifications, then continues through lint, reconciliation, artifact, release, and downstream-delivery gates.

## Validation

- `uv run --frozen pytest -q` — 565 passed, 1 skipped
- Offline report CLI smoke test
- Ruff check and format
- Exact-HEAD `bash scripts/agy-pre-push-review.sh`

Closes #1064