### PR TITLE
fix(release): sanitize validation rule identifiers

### DIFF
--- a/scripts/example_identifier_safety.py
+++ b/scripts/example_identifier_safety.py
@@ -33,6 +33,12 @@ IPV4_WITH_CIDR_RE = re.compile(
 )
 SYNTHETIC_UUID_RE = re.compile(r"00000000-0000-4000-8000-[0-9a-f]{12}$")
 DOCUMENTATION_VALUE_KEYS = frozenset({"description", "example", "examples", "summary", "title"})
+# These values are published alongside their schemas as vendor validation
+# metadata.  They are not wire fields and must not retain realistic identifier
+# literals in release artifacts.
+IDENTIFIER_SANITIZATION_VALUE_KEYS = DOCUMENTATION_VALUE_KEYS | frozenset(
+    {"x-ves-example", "x-ves-validation-rules"}
+)
 DOCUMENTATION_NETWORKS = (
     ipaddress.ip_network("192.0.2.0/24"),
     ipaddress.ip_network("198.51.100.0/24"),
@@ -95,12 +101,12 @@ def _sanitize_text(value: str) -> str:
 
 
 def _sanitize_documentation_value(value: Any, documentation_context: bool = False) -> Any:
-    """Sanitize only OpenAPI documentation text and vendor examples."""
+    """Sanitize published documentation, examples, and validation metadata."""
     if isinstance(value, dict):
         return {
             key: _sanitize_documentation_value(
                 item,
-                documentation_context or key in DOCUMENTATION_VALUE_KEYS or key == "x-ves-example",
+                documentation_context or key in IDENTIFIER_SANITIZATION_VALUE_KEYS,
             )
             for key, item in value.items()
         }

--- a/tests/test_example_identifier_safety.py
+++ b/tests/test_example_identifier_safety.py
@@ -56,6 +56,36 @@ def test_sanitizer_replaces_documentation_addresses_but_preserves_wire_fields() 
     assert sanitize_identifier_examples(sanitized) == sanitized
 
 
+def test_sanitizer_replaces_identifiers_in_published_validation_rules() -> None:
+    private_address = ".".join(("10", "24", "0", "8"))
+    spec = {
+        "components": {
+            "schemas": {
+                "network": {
+                    "properties": {
+                        "configured_vip": {
+                            "x-ves-validation-rules": {
+                                "ves.io.schema.rules.string.not_in": private_address
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    sanitized = sanitize_identifier_examples(spec)
+    findings = find_unsafe_identifiers(sanitized, IdentifierPolicy())
+
+    assert (
+        sanitized["components"]["schemas"]["network"]["properties"]["configured_vip"][
+            "x-ves-validation-rules"
+        ]["ves.io.schema.rules.string.not_in"]
+        == "192.0.2.171"
+    )
+    assert not findings
+
+
 def test_release_gate_rejects_realistic_identifiers_but_allows_documented_synthetic_values() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- sanitize realistic identifiers emitted in `x-ves-validation-rules` metadata
- retain strict release-gate detection for every other string surface
- add a regression test for the failed validation-rule shape

## Root cause

The release gate scans all emitted strings, but the transform previously sanitized only documentation and example contexts. A refreshed upstream spec placed a realistic IPv4 literal in published vendor validation metadata, so the gate failed closed.

## Verification

- `uv run --frozen pytest -q` (566 passed, 1 skipped)
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `bash scripts/check-pii.sh --scope head --mode enforce`
- `bash scripts/agy-pre-push-review.sh`

Closes #1068