### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,8 +1,8 @@
 {
   "spec_date": "2026.08.14",
   "spec_timestamp": "2026-08-14T14:16:06+00:00",
-  "download_date": "2026.08.16",
-  "download_timestamp": "2026-08-16T20:10:57.838879+00:00",
+  "download_date": "2026.08.17",
+  "download_timestamp": "2026-08-17T20:46:40.987505+00:00",
   "etag": "W/\"33e92e-1a000a14c70\"",
   "last_modified": "Fri, 14 Aug 2026 14:16:06 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.