### PR TITLE
fix(docs): remove volatile validation timestamp

### DIFF
--- a/docs/en/01-validation-report.mdx
+++ b/docs/en/01-validation-report.mdx
@@ -7,8 +7,6 @@ description: F5 XC API spec validation and fix report
 
 Validated and reconciled F5 Distributed Cloud OpenAPI specifications.
 
-Generated: 2026-08-17T21:31:22.296219+00:00
-
 ## Summary
 
 | Metric | Count |

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -157,8 +157,6 @@ def generate_fixes_page(report: dict, output_path: Path) -> None:
         "",
         "Validated and reconciled F5 Distributed Cloud OpenAPI specifications.",
         "",
-        f"Generated: {report.get('generated_at', 'unknown')}",
-        "",
         "## Summary",
         "",
         "| Metric | Count |",

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -101,6 +101,8 @@ def test_frontmatter_mapping(tmp_path):
         "---\ntitle: Validation Report\ndescription: F5 XC API spec validation and fix report\n---"
     )
 
+    assert "Generated:" not in content
+
     # Verify MDX-breaking brackets or braces are escaped inside tables too
     assert "| Specs Processed | 1 |" in content
     assert "| **Fixes Applied** | **1** |" in content


### PR DESCRIPTION
Closes #1084\n\nRemoves the wall-clock Generated line from the generated validation page and adds a regression assertion for stable output.