### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -2,7 +2,7 @@
   "spec_date": "2026.08.17",
   "spec_timestamp": "2026-08-17T22:03:37+00:00",
   "download_date": "2026.08.18",
-  "download_timestamp": "2026-08-18T06:40:17.190230+00:00",
+  "download_timestamp": "2026-08-18T14:16:15.823601+00:00",
   "etag": "W/\"33e92e-1a011c066a8\"",
   "last_modified": "Mon, 17 Aug 2026 22:03:37 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.