### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -2,7 +2,7 @@
   "spec_date": "2026.08.20",
   "spec_timestamp": "2026-08-20T00:36:07+00:00",
   "download_date": "2026.08.20",
-  "download_timestamp": "2026-08-20T06:42:13.909362+00:00",
+  "download_timestamp": "2026-08-20T09:01:54.643991+00:00",
   "etag": "W/\"33e92e-1a01c98bcd8\"",
   "last_modified": "Thu, 20 Aug 2026 00:36:07 GMT",
   "file_count": 283,


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.