### PR TITLE
chore: publish regenerated release/specs

### DIFF
--- a/release/specs/.spec_metadata.json
+++ b/release/specs/.spec_metadata.json
@@ -1,10 +1,10 @@
 {
   "spec_date": "2026.08.20",
-  "spec_timestamp": "2026-08-20T00:36:07+00:00",
-  "download_date": "2026.08.20",
-  "download_timestamp": "2026-08-20T09:01:54.643991+00:00",
-  "etag": "W/\"33e92e-1a01c98bcd8\"",
-  "last_modified": "Thu, 20 Aug 2026 00:36:07 GMT",
+  "spec_timestamp": "2026-08-20T16:52:29+00:00",
+  "download_date": "2026.08.21",
+  "download_timestamp": "2026-08-21T12:44:06.733102+00:00",
+  "etag": "W/\"33e92e-1a02016a0c8\"",
+  "last_modified": "Thu, 20 Aug 2026 16:52:29 GMT",
   "file_count": 283,
   "source_url": "https://docs.cloud.f5.com/docs-v2/downloads/f5-distributed-cloud-open-api.zip"
 }


### PR DESCRIPTION
Auto-generated: the pipeline produced a `release/specs` that differs from the committed artifact. See #681.