### PR TITLE
Reconcile canonical linked-issue workflow

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,173 +1,39 @@
 ---
 name: Require Linked Issue
 
-#checkov:skip=CKV_GHA_7:Targeted inputs are exact PR receipts validated before a status is written.
 on:
-  schedule:
-    - cron: '*/5 * * * *'
-  workflow_dispatch:
-    inputs:
-      pull_request_number:
-        description: Exact pull request to evaluate, including a just-merged bootstrap PR
-        required: false
-        type: string
-      expected_head_sha:
-        description: Full head SHA that the targeted pull request must still reference
-        required: false
-        type: string
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 permissions: {}
 
-concurrency:
-  group: require-linked-issue
-  cancel-in-progress: false
-
 jobs:
-  check:
+  check-linked-issues:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Check linked issues
     runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
-      issues: write # read linked issues and publish one deduplicated guidance comment
-      pull-requests: read # enumerate open pull requests and linked-issue references
-      statuses: write # publish the existing required context on each pull request head
+      pull-requests: read
     steps:
-      - name: Enforce linked issues
+      - name: Check this pull request's linked issues
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const EXCLUDE_BRANCHES = "dependabot/**,release/**,changeset-release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,governance/sync-managed-files-*,docs/update-*";
-            const MARKER = "<!-- require-linked-issue -->";
-            const MESSAGE = `${MARKER}\nThis PR must be linked to a GitHub issue. Use 'Closes #123' in the PR description, or link an issue from the sidebar.`;
-            const STATUS_CONTEXT = "Check linked issues";
             const { owner, repo } = context.repo;
-            const scheduled = context.eventName === "schedule";
-
-            const hasExhaustedStatusContext = (error) =>
-              error?.status === 422 &&
-              String(error?.response?.data?.errors ?? error?.message ?? "").includes(
-                "This SHA and context has reached the maximum number of statuses",
-              );
-
-            const globToRegex = (glob) => {
-              const escaped = glob
-                .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-                .replace(/\*\*/g, "__DOUBLE_STAR__")
-                .replace(/\*/g, "[^/]*")
-                .replace(/__DOUBLE_STAR__/g, ".*");
-              return new RegExp(`^${escaped}$`);
-            };
-            const excludedBranches = EXCLUDE_BRANCHES.split(",").map((pattern) =>
-              globToRegex(pattern.trim()),
+            const number = context.payload.pull_request.number;
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 1) { nodes { number } }
+                  }
+                }
+              }`,
+              { owner, repo, number },
             );
-
-            const inputs = context.eventName === "workflow_dispatch" ? context.payload.inputs ?? {} : {};
-            const requestedNumber = inputs.pull_request_number ?? "";
-            const requestedHead = inputs.expected_head_sha ?? "";
-            let pulls;
-            if (requestedNumber !== "" || requestedHead !== "") {
-              if (!/^[1-9][0-9]*$/.test(requestedNumber) || !/^[0-9a-f]{40}$/.test(requestedHead)) {
-                throw new Error("Targeted linked-issue evaluation requires an exact PR number and head SHA");
-              }
-              const { data: pull } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: Number(requestedNumber),
-              });
-              if (pull.head.sha !== requestedHead) {
-                throw new Error(`PR #${requestedNumber} head changed before linked-issue evaluation`);
-              }
-              pulls = [pull];
+            const linked = result.repository.pullRequest.closingIssuesReferences.nodes;
+            if (linked.length === 0) {
+              core.setFailed("Pull request must link a GitHub issue. Add 'Closes #123' to the PR description or link an issue from the sidebar.");
             } else {
-              pulls = await github.paginate(github.rest.pulls.list, {
-                owner,
-                repo,
-                state: "open",
-                per_page: 100,
-              });
-            }
-            const evaluationErrors = [];
-
-            for (const pull of pulls) {
-              const headSha = pull.head.sha;
-              const postStatus = async (state, description) => {
-                try {
-                  await github.rest.repos.createCommitStatus({
-                    owner,
-                    repo,
-                    sha: headSha,
-                    state,
-                    context: STATUS_CONTEXT,
-                    description,
-                  });
-                  return true;
-                } catch (error) {
-                  if (scheduled && hasExhaustedStatusContext(error)) {
-                    core.warning(
-                      `PR #${pull.number}: skipping historical SHA with exhausted ${STATUS_CONTEXT} status capacity`,
-                    );
-                    return false;
-                  }
-                  throw error;
-                }
-              };
-
-              if (!(await postStatus("pending", "Checking for a linked issue"))) {
-                continue;
-              }
-              try {
-                if (excludedBranches.some((pattern) => pattern.test(pull.head.ref))) {
-                  if (!(await postStatus("success", "Automated branch is exempt"))) {
-                    continue;
-                  }
-                  continue;
-                }
-
-                const result = await github.graphql(
-                  `query($owner: String!, $repo: String!, $number: Int!) {
-                    repository(owner: $owner, name: $repo) {
-                      pullRequest(number: $number) {
-                        closingIssuesReferences(first: 10) { nodes { number } }
-                      }
-                    }
-                  }`,
-                  { owner, repo, number: pull.number },
-                );
-                const linked = result.repository.pullRequest.closingIssuesReferences.nodes;
-                if (linked.length > 0) {
-                  const refs = linked.map((node) => `#${node.number}`).join(", ");
-                  core.info(`PR #${pull.number} links ${refs}`);
-                  if (!(await postStatus("success", "Linked issue found"))) {
-                    continue;
-                  }
-                  continue;
-                }
-
-                const comments = await github.paginate(github.rest.issues.listComments, {
-                  owner,
-                  repo,
-                  issue_number: pull.number,
-                  per_page: 100,
-                });
-                if (!comments.some((comment) => comment.body?.includes(MARKER))) {
-                  await github.rest.issues.createComment({
-                    owner,
-                    repo,
-                    issue_number: pull.number,
-                    body: MESSAGE,
-                  });
-                }
-                if (!(await postStatus("failure", "Pull request has no linked issue"))) {
-                  continue;
-                }
-              } catch (error) {
-                if (!(await postStatus("failure", "Linked-issue evaluation failed"))) {
-                  continue;
-                }
-                core.error(`PR #${pull.number}: ${error.message}`);
-                evaluationErrors.push(pull.number);
-              }
-            }
-
-            if (evaluationErrors.length > 0) {
-              core.setFailed(`Linked-issue evaluation failed for PRs: ${evaluationErrors.join(", ")}`);
+              core.info(`PR #${number} links issue #${linked[0].number}`);
             }


### PR DESCRIPTION
Closes #1119

Replaces only the legacy linked-issue workflow with the canonical PR-only, read-only workflow. The workflow remains disabled until the separate verification PR is ready.